### PR TITLE
Bump generate-template-plugin

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "@codemirror/lang-xml": "^0.20.0",
         "@lblod/ember-mock-login": "^0.7.0",
         "@lblod/ember-rdfa-editor-article-structure-plugin": "^0.3.0",
-        "@lblod/ember-rdfa-editor-generate-template-plugin": "^0.1.3",
+        "@lblod/ember-rdfa-editor-generate-template-plugin": "^0.1.4",
         "@lblod/ember-rdfa-editor-table-of-contents-plugin": "^0.4.0",
         "@triply/yasgui": "^4.2.26",
         "date-fns": "^2.29.1",
@@ -4618,9 +4618,9 @@
       }
     },
     "node_modules/@lblod/ember-rdfa-editor-generate-template-plugin": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/@lblod/ember-rdfa-editor-generate-template-plugin/-/ember-rdfa-editor-generate-template-plugin-0.1.3.tgz",
-      "integrity": "sha512-EktUBvAAOzbfj4CQwAPLnRrpJopESy0JRWhQ4TjqMRHjTRaLDCcFus4mpVTREooxNeEFKROMG/Q0beitmYecnw==",
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/@lblod/ember-rdfa-editor-generate-template-plugin/-/ember-rdfa-editor-generate-template-plugin-0.1.4.tgz",
+      "integrity": "sha512-nN86WUt4QXPEOeJz0pSX63c8pMpHh7CamtqDh20drzYDqs5Oh8lHLMhPh53fo+0xxC6fzubZmIpht+gpPDXKvw==",
       "dependencies": {
         "@glimmer/component": "^1.0.4",
         "@glimmer/tracking": "^1.0.4",
@@ -4634,7 +4634,7 @@
         "node": "12.* || 14.* || >= 16"
       },
       "peerDependencies": {
-        "@lblod/ember-rdfa-editor": ">=0.60.5",
+        "@lblod/ember-rdfa-editor": ">=0.63.3",
         "ember-concurrency": "^2.2.0"
       }
     },
@@ -38239,9 +38239,9 @@
       }
     },
     "@lblod/ember-rdfa-editor-generate-template-plugin": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/@lblod/ember-rdfa-editor-generate-template-plugin/-/ember-rdfa-editor-generate-template-plugin-0.1.3.tgz",
-      "integrity": "sha512-EktUBvAAOzbfj4CQwAPLnRrpJopESy0JRWhQ4TjqMRHjTRaLDCcFus4mpVTREooxNeEFKROMG/Q0beitmYecnw==",
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/@lblod/ember-rdfa-editor-generate-template-plugin/-/ember-rdfa-editor-generate-template-plugin-0.1.4.tgz",
+      "integrity": "sha512-nN86WUt4QXPEOeJz0pSX63c8pMpHh7CamtqDh20drzYDqs5Oh8lHLMhPh53fo+0xxC6fzubZmIpht+gpPDXKvw==",
       "requires": {
         "@glimmer/component": "^1.0.4",
         "@glimmer/tracking": "^1.0.4",

--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
     "@codemirror/lang-xml": "^0.20.0",
     "@lblod/ember-mock-login": "^0.7.0",
     "@lblod/ember-rdfa-editor-article-structure-plugin": "^0.3.0",
-    "@lblod/ember-rdfa-editor-generate-template-plugin": "^0.1.3",
+    "@lblod/ember-rdfa-editor-generate-template-plugin": "^0.1.4",
     "@lblod/ember-rdfa-editor-table-of-contents-plugin": "^0.4.0",
     "@triply/yasgui": "^4.2.26",
     "date-fns": "^2.29.1",


### PR DESCRIPTION
Update generate-template-plugin which fixes issues when exporting the html from the document. This prevents issues with the table of contents being incorrectly exported.
Solves https://binnenland.atlassian.net/browse/GN-3682?atlOrigin=eyJpIjoiMjQzMDI0OTU1Yzk3NDk0ZmI3Yzc4YzJjY2UxNTdhOGIiLCJwIjoiaiJ9.