### PR TITLE
Save document title after editing it

### DIFF
--- a/app/components/app-chrome.hbs
+++ b/app/components/app-chrome.hbs
@@ -37,7 +37,8 @@
         {{t "utility.unsavedConcept"}}
       </AuPill>
       {{/if}}
-      <EditorDocumentTitle @title={{@editorDocument.title}} @editActive={{@editorDocument.isNew}} @onChange={{this.updateDocumentTitle}} @readOnly={{@readOnly}} />
+      <EditorDocumentTitle @title={{@editorDocument.title}} @editActive={{@editorDocument.isNew}}
+        @onChange={{this.updateDocumentTitle}} @onSubmit={{this.saveDocument}} @readOnly={{@readOnly}} />
     </AuToolbarGroup>
     <AuToolbarGroup>
       {{#if @editorDocument.isNew}}

--- a/app/components/app-chrome.hbs
+++ b/app/components/app-chrome.hbs
@@ -1,89 +1,91 @@
 <nav>
   <div class="au-c-app-chrome">
-  <AuToolbar @size="small" class="au-u-padding-bottom-none">
-    <AuToolbarGroup>
-      <AuLink @route={{@returnRoute}} @skin="secondary">
-        <AuIcon @icon="arrow-left" @alignment="left" />
-        {{@returnRouteText}}
-      </AuLink>
-      <span class="au-c-app-chrome__entity">{{this.currentSession.group.classificatie.label}} {{this.currentSession.group.naam}}</span>
-    </AuToolbarGroup>
-    <AuToolbarGroup>
-      <ul class="au-c-list-horizontal au-u-padding-right-tiny">
-        {{#unless @editorDocument.isNew}}
-        {{#if @editorDocument.updatedOn}}
-        <li class="au-c-list-horizontal__item">
-          <span class="au-c-app-chrome__status">
-            {{t "utility.savedOn"}} {{human-friendly-date @editorDocument.updatedOn}}
-          </span>
-        </li>
-        {{else}}
-        <li class="au-c-list-horizontal__item">
-          <span class="au-c-app-chrome__status">
-            <AuIcon @icon="alert-triangle" @alignment="left" />
-            {{t "utility.unsavedChanges"}}
-          </span>
-        </li>
+    <AuToolbar @size="small" class="au-u-padding-bottom-none">
+      <AuToolbarGroup>
+        <AuLink @route={{@returnRoute}} @skin="secondary">
+          <AuIcon @icon="arrow-left" @alignment="left" />
+          {{@returnRouteText}}
+        </AuLink>
+        <span class="au-c-app-chrome__entity">{{this.currentSession.group.classificatie.label}}
+          {{this.currentSession.group.naam}}</span>
+      </AuToolbarGroup>
+      <AuToolbarGroup>
+        <ul class="au-c-list-horizontal au-u-padding-right-tiny">
+          {{#unless @editorDocument.isNew}}
+          {{#if @editorDocument.updatedOn}}
+          <li class="au-c-list-horizontal__item">
+            <span class="au-c-app-chrome__status">
+              {{t "utility.savedOn"}} {{human-friendly-date @editorDocument.updatedOn}}
+            </span>
+          </li>
+          {{else}}
+          <li class="au-c-list-horizontal__item">
+            <span class="au-c-app-chrome__status">
+              <AuIcon @icon="alert-triangle" @alignment="left" />
+              {{t "utility.unsavedChanges"}}
+            </span>
+          </li>
+          {{/if}}
+          {{/unless}}
+        </ul>
+      </AuToolbarGroup>
+    </AuToolbar>
+    <AuToolbar @size="small" class="au-u-padding-top-none">
+      <AuToolbarGroup>
+        {{#if @editorDocument.isNew}}
+        <AuPill @skin="warning">
+          <AuIcon @icon="alert-triangle" @alignment="left" />
+          {{t "utility.unsavedConcept"}}
+        </AuPill>
         {{/if}}
-        {{/unless}}
-      </ul>
-    </AuToolbarGroup>
-  </AuToolbar>
-  <AuToolbar @size="small" class="au-u-padding-top-none">
-    <AuToolbarGroup>
-      {{#if @editorDocument.isNew}}
-      <AuPill @skin="warning">
-        <AuIcon @icon="alert-triangle" @alignment="left" />
-        {{t "utility.unsavedConcept"}}
-      </AuPill>
-      {{/if}}
-      <EditorDocumentTitle @title={{@editorDocument.title}} @editActive={{@editorDocument.isNew}}
-        @onChange={{this.updateDocumentTitle}} @onSubmit={{this.saveDocument}} @readOnly={{@readOnly}} />
-    </AuToolbarGroup>
-    <AuToolbarGroup>
-      {{#if @editorDocument.isNew}}
-        <LinkTo @route="inbox.agendapoints" class="au-c-button au-c-button--tertiary au-c-button--alert" role="menuitem">
+        <EditorDocumentTitle @title={{@editorDocument.title}} @editActive={{@editorDocument.isNew}}
+          @onChange={{this.updateDocumentTitle}} @onSubmit={{this.saveDocument}} @onCancel={{this.resetDocument}}
+          @readOnly={{@readOnly}} />
+      </AuToolbarGroup>
+      <AuToolbarGroup>
+        {{#if @editorDocument.isNew}}
+        <LinkTo @route="inbox.agendapoints" class="au-c-button au-c-button--tertiary au-c-button--alert"
+          role="menuitem">
           <AuIcon @icon="bin" @alignment="left" />
           {{t "utility.removeConcept"}}
         </LinkTo>
-      {{else if this.showFileDropDown}}
-      <AuDropdown @title="Bestand acties" @buttonLabel="Bestand opties" @alignment="right">
-        {{#if @copyAgendapunt}}
+        {{else if this.showFileDropDown}}
+        <AuDropdown @title="Bestand acties" @buttonLabel="Bestand opties" @alignment="right">
+          {{#if @copyAgendapunt}}
           <AuButton {{on "click" @copyAgendapunt}} @skin="tertiary" role="menuitem">
             <AuIcon @icon="copy" @alignment="left" />
             {{t "appChrome.copyAgendapoint"}}
           </AuButton>
-        {{/if}}
-        {{#if @exportHtmlFunction}}
+          {{/if}}
+          {{#if @exportHtmlFunction}}
           <AuButton {{on "click" @exportHtmlFunction}} @skin="tertiary" role="menuitem">
             <AuIcon @icon="export" @alignment="left" />
             {{t "utility.exportToHtml"}}
           </AuButton>
+          {{/if}}
+          {{#if @sendToTrash}}
+          <AuButton {{on "click" @sendToTrash}} @skin="tertiary" @alert="true" role="menuitem"
+            @disabled={{this.isNotAllowedToTrash}}>
+            <AuIcon @icon="bin" @alignment="left" />
+            {{t "utility.toRecycleBin"}}
+          </AuButton>
+          {{/if}}
+        </AuDropdown>
         {{/if}}
-        {{#if @sendToTrash}}
-        <AuButton {{on "click" @sendToTrash}} @skin="tertiary" @alert="true" role="menuitem" @disabled={{this.isNotAllowedToTrash}}>
-          <AuIcon @icon="bin" @alignment="left" />
-          {{t "utility.toRecycleBin"}}
-        </AuButton>
-        {{/if}}
-      </AuDropdown>
-      {{/if}}
-      {{#if @isPublished}}
-        <AuPill
-          @skin="success"
-          @icon="eye"
-        >
+        {{#if @isPublished}}
+        <AuPill @skin="success" @icon="eye">
           {{t "utility.available"}}
         </AuPill>
-      {{/if}}
+        {{/if}}
 
-      {{#if @save}}
+        {{#if @save}}
         <AuButton {{on "click" @save.action}} @disabled={{@save.isRunning}}>{{t "utility.save"}}</AuButton>
-      {{/if}}
-      {{#if @publish}}
-        <AuButton {{on "click" @publish.action}} @disabled={{@publish.isRunning}}>{{t "utility.saveAndPublish"}}</AuButton>
-      {{/if}}
-    </AuToolbarGroup>
-  </AuToolbar>
+        {{/if}}
+        {{#if @publish}}
+        <AuButton {{on "click" @publish.action}} @disabled={{@publish.isRunning}}>{{t "utility.saveAndPublish"}}
+        </AuButton>
+        {{/if}}
+      </AuToolbarGroup>
+    </AuToolbar>
   </div>
 </nav>

--- a/app/components/app-chrome.js
+++ b/app/components/app-chrome.js
@@ -20,12 +20,12 @@ export default class AppChromeComponent extends Component {
   }
 
   @action
-  async updateDocumentTitle(title) {
+  updateDocumentTitle(title) {
     this.args.editorDocument.title = title;
   }
 
   @action
   async saveDocument() {
-    this.args.editorDocument.save();
+    await this.args.editorDocument.save();
   }
 }

--- a/app/components/app-chrome.js
+++ b/app/components/app-chrome.js
@@ -25,6 +25,11 @@ export default class AppChromeComponent extends Component {
   }
 
   @action
+  async resetDocument() {
+    this.args.editorDocument.rollbackAttributes();
+  }
+
+  @action
   async saveDocument() {
     await this.args.editorDocument.save();
   }

--- a/app/components/app-chrome.js
+++ b/app/components/app-chrome.js
@@ -20,7 +20,12 @@ export default class AppChromeComponent extends Component {
   }
 
   @action
-  updateDocumentTitle(title) {
+  async updateDocumentTitle(title) {
     this.args.editorDocument.title = title;
+  }
+
+  @action
+  async saveDocument() {
+    this.args.editorDocument.save();
   }
 }

--- a/app/components/editor-document-title.hbs
+++ b/app/components/editor-document-title.hbs
@@ -1,19 +1,45 @@
 {{#if @readOnly}}
-  <h1 class="au-u-h3">
+  <h1 class='au-u-h3'>
     {{this.title}}
   </h1>
 {{else}}
   {{#if this.active}}
-    <div class="au-c-app-chrome__title-group au-u-flex au-u-flex--spaced-tiny">
-      {{#let (unique-id) as |id|}}
-        <AuLabel for={{id}}  class="au-u-hidden-visually">{{t "reglementaireBijlageTitel.description"}}</AuLabel>
-        <input class="au-c-input au-c-app-chrome__title-input {{if this.error "au-c-input--error"}}" placeholder={{t "reglementaireBijlageTitel.placeholder"}} id={{id}} type="text" value={{this.title}} {{on "input" this.setTitle}} />
-      {{/let}}
-      <AuButton {{on "click" this.toggleActive}} @skin="secondary" @icon="check" @hideText={{true}}>{{t "reglementaireBijlageTitel.modify"}}</AuButton>
-    </div>
+    <form {{on 'submit' this.submit}}>
+      <div
+        class='au-c-app-chrome__title-group au-u-flex au-u-flex--spaced-tiny'
+      >
+        {{#let (unique-id) as |id|}}
+          <AuLabel for={{id}} class='au-u-hidden-visually'>{{t
+              'reglementaireBijlageTitel.description'
+            }}</AuLabel>
+          <input
+            class='au-c-input au-c-app-chrome__title-input
+              {{if this.error "au-c-input--error"}}'
+            placeholder={{t 'reglementaireBijlageTitel.placeholder'}}
+            id={{id}}
+            type='text'
+            value={{this.title}}
+            {{on 'input' this.setTitle}}
+            {{did-insert this.focus}}
+          />
+        {{/let}}
+        <AuButton
+          type='submit'
+          @skin='secondary'
+          @icon='check'
+          @hideText={{true}}
+        >{{t 'reglementaireBijlageTitel.modify'}}</AuButton>
+      </div>
+    </form>
   {{else}}
-    <h1 class="au-u-h3">
-      {{this.title}} <AuButton {{on "click" this.toggleActive}} @icon="pencil" @skin="tertiary" @hideText={{true}} >titel wijzigen</AuButton>
+    <h1 class='au-u-h3'>
+      {{this.title}}
+      <AuButton
+        {{on 'click' this.toggleActive}}
+        @icon='pencil'
+        @skin='tertiary'
+        @hideText={{true}}
+      >titel wijzigen</AuButton>
     </h1>
   {{/if}}
 

--- a/app/components/editor-document-title.hbs
+++ b/app/components/editor-document-title.hbs
@@ -1,43 +1,43 @@
 {{#if @readOnly}}
-  <h1 class='au-u-h3'>
+  <h1 class="au-u-h3">
     {{this.title}}
   </h1>
 {{else}}
   {{#if this.active}}
-    <form {{on 'submit' this.submit}}>
+    <form {{on "submit" this.submit}}>
       <div
-        class='au-c-app-chrome__title-group au-u-flex au-u-flex--spaced-tiny'
+        class="au-c-app-chrome__title-group au-u-flex au-u-flex--spaced-tiny"
       >
         {{#let (unique-id) as |id|}}
-          <AuLabel for={{id}} class='au-u-hidden-visually'>{{t
-              'reglementaireBijlageTitel.description'
+          <AuLabel for={{id}} class="au-u-hidden-visually">{{t
+              "reglementaireBijlageTitel.description"
             }}</AuLabel>
           <input
-            class='au-c-input au-c-app-chrome__title-input
-              {{if this.error "au-c-input--error"}}'
-            placeholder={{t 'reglementaireBijlageTitel.placeholder'}}
+            class="au-c-input au-c-app-chrome__title-input
+              {{if this.error "au-c-input--error"}}"
+            placeholder={{t "reglementaireBijlageTitel.placeholder"}}
             id={{id}}
-            type='text'
+            type="text"
             value={{this.title}}
-            {{on 'input' this.setTitle}}
+            {{on "input" this.setTitle}}
             {{did-insert this.focus}}
           />
         {{/let}}
         <AuButton
-          type='submit'
-          @skin='secondary'
-          @icon='check'
+          type="submit"
+          @skin="secondary"
+          @icon="check"
           @hideText={{true}}
-        >{{t 'reglementaireBijlageTitel.modify'}}</AuButton>
+        >{{t "reglementaireBijlageTitel.modify"}}</AuButton>
       </div>
     </form>
   {{else}}
-    <h1 class='au-u-h3'>
+    <h1 class="au-u-h3">
       {{this.title}}
       <AuButton
-        {{on 'click' this.toggleActive}}
-        @icon='pencil'
-        @skin='tertiary'
+        {{on "click" this.toggleActive}}
+        @icon="pencil"
+        @skin="tertiary"
         @hideText={{true}}
       >titel wijzigen</AuButton>
     </h1>

--- a/app/components/editor-document-title.hbs
+++ b/app/components/editor-document-title.hbs
@@ -4,7 +4,7 @@
   </h1>
 {{else}}
   {{#if this.active}}
-    <form {{on "submit" this.submit}}>
+    <form {{on "submit" this.submit}} {{on "focusout" this.cancel}}>
       <div
         class="au-c-app-chrome__title-group au-u-flex au-u-flex--spaced-tiny"
       >

--- a/app/components/editor-document-title.js
+++ b/app/components/editor-document-title.js
@@ -27,11 +27,22 @@ export default class EditorDocumentTitleComponent extends Component {
   }
 
   @action
+  submit() {
+    this.args.onSubmit?.();
+    this.toggleActive();
+  }
+
+  @action
   toggleActive() {
     if (this.active && !this.title) {
       this.error = true;
     } else {
       this.active = !this.active;
     }
+  }
+
+  @action
+  focus(element) {
+    element.focus();
   }
 }

--- a/app/components/editor-document-title.js
+++ b/app/components/editor-document-title.js
@@ -33,6 +33,14 @@ export default class EditorDocumentTitleComponent extends Component {
   }
 
   @action
+  cancel(event) {
+    if (!event.currentTarget.contains(event.relatedTarget)) {
+      this.args.onCancel?.();
+      this.toggleActive();
+    }
+  }
+
+  @action
   toggleActive() {
     if (this.active && !this.title) {
       this.error = true;


### PR DESCRIPTION
This ensures that the title of the document is saved just after having edited it. An additional save of the document is no longer required. Solves https://binnenland.atlassian.net/jira/software/c/projects/GN/boards/4?modal=detail&selectedIssue=GN-3734.