### PR TITLE
Bump generate template plugin to 0.1.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "@codemirror/lang-xml": "^0.20.0",
         "@lblod/ember-mock-login": "^0.7.0",
         "@lblod/ember-rdfa-editor-article-structure-plugin": "^0.3.1",
-        "@lblod/ember-rdfa-editor-generate-template-plugin": "^0.1.4",
+        "@lblod/ember-rdfa-editor-generate-template-plugin": "^0.1.5",
         "@lblod/ember-rdfa-editor-table-of-contents-plugin": "^0.4.3",
         "@triply/yasgui": "^4.2.26",
         "date-fns": "^2.29.1",
@@ -4618,9 +4618,9 @@
       }
     },
     "node_modules/@lblod/ember-rdfa-editor-generate-template-plugin": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/@lblod/ember-rdfa-editor-generate-template-plugin/-/ember-rdfa-editor-generate-template-plugin-0.1.4.tgz",
-      "integrity": "sha512-nN86WUt4QXPEOeJz0pSX63c8pMpHh7CamtqDh20drzYDqs5Oh8lHLMhPh53fo+0xxC6fzubZmIpht+gpPDXKvw==",
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/@lblod/ember-rdfa-editor-generate-template-plugin/-/ember-rdfa-editor-generate-template-plugin-0.1.5.tgz",
+      "integrity": "sha512-zfsFQH+9pEqYqJejpN8CpKzN3RxrlRA9a08bnC+th3R6WU4nOvK2QllIm5z0oL4rxiyRe8dQ9fO7emSE5tPGig==",
       "dependencies": {
         "@glimmer/component": "^1.0.4",
         "@glimmer/tracking": "^1.0.4",
@@ -38239,9 +38239,9 @@
       }
     },
     "@lblod/ember-rdfa-editor-generate-template-plugin": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/@lblod/ember-rdfa-editor-generate-template-plugin/-/ember-rdfa-editor-generate-template-plugin-0.1.4.tgz",
-      "integrity": "sha512-nN86WUt4QXPEOeJz0pSX63c8pMpHh7CamtqDh20drzYDqs5Oh8lHLMhPh53fo+0xxC6fzubZmIpht+gpPDXKvw==",
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/@lblod/ember-rdfa-editor-generate-template-plugin/-/ember-rdfa-editor-generate-template-plugin-0.1.5.tgz",
+      "integrity": "sha512-zfsFQH+9pEqYqJejpN8CpKzN3RxrlRA9a08bnC+th3R6WU4nOvK2QllIm5z0oL4rxiyRe8dQ9fO7emSE5tPGig==",
       "requires": {
         "@glimmer/component": "^1.0.4",
         "@glimmer/tracking": "^1.0.4",

--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
     "@codemirror/lang-xml": "^0.20.0",
     "@lblod/ember-mock-login": "^0.7.0",
     "@lblod/ember-rdfa-editor-article-structure-plugin": "^0.3.1",
-    "@lblod/ember-rdfa-editor-generate-template-plugin": "^0.1.4",
+    "@lblod/ember-rdfa-editor-generate-template-plugin": "^0.1.5",
     "@lblod/ember-rdfa-editor-table-of-contents-plugin": "^0.4.3",
     "@triply/yasgui": "^4.2.26",
     "date-fns": "^2.29.1",


### PR DESCRIPTION
This PR includes an update of the generate template to 0.1.5. 0.1.5 fixes an issue with incorrectly formatted `generateUuid()` placeholders.