### PR TITLE
Refresh data when a regulatory statement has been removed or published

### DIFF
--- a/app/controllers/list.js
+++ b/app/controllers/list.js
@@ -82,7 +82,8 @@ export default class ListController extends Controller.extend(
     }
     yield this.reglement.save();
     this.removeReglementModalIsOpen = false;
-    this.router.transitionTo('list');
+    this.refresh();
+    // this.router.transitionTo('list');
   }
 
   @task

--- a/app/controllers/list.js
+++ b/app/controllers/list.js
@@ -83,7 +83,6 @@ export default class ListController extends Controller.extend(
     yield this.reglement.save();
     this.removeReglementModalIsOpen = false;
     this.refresh();
-    // this.router.transitionTo('list');
   }
 
   @task

--- a/app/controllers/publish.js
+++ b/app/controllers/publish.js
@@ -1,6 +1,6 @@
 import Controller from '@ember/controller';
 import { inject as service } from '@ember/service';
-import { task } from 'ember-concurrency';
+import { task, timeout } from 'ember-concurrency';
 import { tracked } from '@glimmer/tracking';
 export default class PublishController extends Controller {
   @service store;
@@ -36,7 +36,7 @@ export default class PublishController extends Controller {
     );
     publicationTask.regulatoryAttachment = this.model.reglement;
     yield publicationTask.save();
+    yield this.muTask.waitForMuTaskTask.perform(publicationTask.id, 100);
     yield this.fetchPreview.perform();
-    // this.router.transitionTo('edit', this.model.reglement.id);
   }
 }

--- a/app/controllers/publish.js
+++ b/app/controllers/publish.js
@@ -16,11 +16,13 @@ export default class PublishController extends Controller {
 
   @task
   *fetchPreview() {
+    console.log('FETCH PREVIEW');
     this.currentVersion = '';
-    const publishedVersionContainer = yield this.model.reglement
-      .publishedVersion;
+    const publishedVersionContainer =
+      yield this.model.reglement.publishedVersion.reload();
     if (publishedVersionContainer) {
-      const publishedVersion = yield publishedVersionContainer.currentVersion;
+      const publishedVersion =
+        yield publishedVersionContainer.currentVersion.reload();
       const publishedVersionContent = yield publishedVersion.content;
       const response = yield fetch(publishedVersionContent.downloadLink);
       this.currentVersion = yield response.text();
@@ -36,6 +38,6 @@ export default class PublishController extends Controller {
     publicationTask.regulatoryAttachment = this.model.reglement;
     yield publicationTask.save();
     yield this.fetchPreview.perform();
-    this.router.transitionTo('edit', this.model.reglement.id);
+    // this.router.transitionTo('edit', this.model.reglement.id);
   }
 }

--- a/app/controllers/publish.js
+++ b/app/controllers/publish.js
@@ -16,7 +16,6 @@ export default class PublishController extends Controller {
 
   @task
   *fetchPreview() {
-    console.log('FETCH PREVIEW');
     this.currentVersion = '';
     const publishedVersionContainer =
       yield this.model.reglement.publishedVersion.reload();

--- a/app/models/regulatory-attachment-publication-task.js
+++ b/app/models/regulatory-attachment-publication-task.js
@@ -1,5 +1,6 @@
-import Model, { belongsTo } from '@ember-data/model';
+import Model, { attr, belongsTo } from '@ember-data/model';
 
 export default class RegulatoryAttachmentPublicationTask extends Model {
   @belongsTo('regulatory-statement') regulatoryAttachment;
+  @attr status;
 }

--- a/app/routes/list.js
+++ b/app/routes/list.js
@@ -28,6 +28,12 @@ export default class ListRoute extends Route.extend(DataTableRouteMixin) {
     return reglements;
   }
 
+  setupController(controller, model) {
+    super.setupController(controller, model);
+
+    controller.set('refresh', this.refresh.bind(this));
+  }
+
   beforeModel(transition) {
     this.session.requireAuthentication(transition, 'login');
   }

--- a/app/routes/publish.js
+++ b/app/routes/publish.js
@@ -5,7 +5,6 @@ export default class PublishRoute extends Route {
   @service session;
 
   async model(params) {
-    console.log('MODEL');
     const reglement = await this.store.findRecord(
       'regulatory-statement',
       params.id,

--- a/app/routes/publish.js
+++ b/app/routes/publish.js
@@ -5,15 +5,18 @@ export default class PublishRoute extends Route {
   @service session;
 
   async model(params) {
+    console.log('MODEL');
     const reglement = await this.store.findRecord(
       'regulatory-statement',
-      params.id
+      params.id,
+      { reload: true }
     );
     const document = await reglement.get('document');
     const currentVersion = await document.get('currentVersion');
     const templateVersion = await currentVersion.get('templateVersion');
     return { reglement: reglement, templateVersion };
   }
+
   beforeModel(transition) {
     this.session.requireAuthentication(transition, 'login');
   }

--- a/app/services/mu-task.js
+++ b/app/services/mu-task.js
@@ -1,7 +1,7 @@
 import Service from '@ember/service';
 import { task, timeout } from 'ember-concurrency';
 
-const TASK_ENDPOINT = '/publication-tasks';
+const TASK_ENDPOINT = '/regulatory-attachment-publication-tasks';
 export const TASK_STATUS_FAILURE =
   'http://lblod.data.gift/besluit-publicatie-melding-statuses/failure';
 export const TASK_STATUS_CREATED =


### PR DESCRIPTION
This PR includes some changes which refresh the data of the route when having removed or published a regulatory statement template.

TODO:
- [x] We should wait until the publication-task has finished before reload the published template.