### PR TITLE
Navigation of publish page and addition of `published` notification

### DIFF
--- a/app/controllers/publish.js
+++ b/app/controllers/publish.js
@@ -1,6 +1,6 @@
 import Controller from '@ember/controller';
 import { inject as service } from '@ember/service';
-import { task, timeout } from 'ember-concurrency';
+import { task } from 'ember-concurrency';
 import { tracked } from '@glimmer/tracking';
 export default class PublishController extends Controller {
   @service store;
@@ -8,6 +8,9 @@ export default class PublishController extends Controller {
   @service session;
   @service currentSession;
   @service muTask;
+  @service toaster;
+  @service intl;
+
   @tracked currentVersion;
 
   constructor() {
@@ -38,5 +41,12 @@ export default class PublishController extends Controller {
     yield publicationTask.save();
     yield this.muTask.waitForMuTaskTask.perform(publicationTask.id, 100);
     yield this.fetchPreview.perform();
+    this.toaster.success(
+      this.intl.t('publishPage.notificationContent'),
+      this.intl.t('publishPage.notificationTitle'),
+      {
+        timeOut: 3000,
+      }
+    );
   }
 }

--- a/app/templates/publish.hbs
+++ b/app/templates/publish.hbs
@@ -1,5 +1,6 @@
 {{page-title 'Publish'}}
 <AuBodyContainer @scroll="true">
+  <AuToaster @position="top" />
   <div class='au-o-box'>
     <AuHeading class="au-u-margin-bottom">{{t "publishPage.title"}}</AuHeading>
     <div class='au-o-grid au-o-grid--small' {{did-insert (perform this.fetchPreview)}}>

--- a/app/templates/publish.hbs
+++ b/app/templates/publish.hbs
@@ -1,4 +1,19 @@
 {{page-title 'Publish'}}
+<AuToolbar @size="small" class="au-u-padding-bottom-none" as |Group|>
+  <Group>
+    <ul class="au-c-list-horizontal au-c-list-horizontal--small">
+      <li class="au-c-list-horizontal__item">
+        <AuLink @linkRoute="edit" @model={{model.reglement.id}} >
+          <AuIcon @icon="arrow-left" @alignment="left" />
+          {{t "publishPage.back"}}
+        </AuLink>
+      </li>
+      <li class="au-c-list-horizontal__item">
+        {{t "publishPage.titleShort"}}
+      </li>
+    </ul>
+  </Group>
+</AuToolbar>
 <AuBodyContainer @scroll="true">
   <AuToaster @position="top" />
   <div class='au-o-box'>

--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -81,6 +81,8 @@ auth:
   logout: Log out
 publishPage:
   title: Publish regulatory statement template
+  titleShort: Publish template
+  back: Back to regulatory statement
   latestversion: Latest version
   publishedversion: Published version
   publish: Publicize

--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -84,6 +84,8 @@ publishPage:
   latestversion: Latest version
   publishedversion: Published version
   publish: Publicize
+  notificationTitle: Success
+  notificationContent: Template successfully published
 reglementaireBijlageTitel:
   description: "Regulatory statement title"
   placeholder: "Untitled document"

--- a/translations/nl-BE.yaml
+++ b/translations/nl-BE.yaml
@@ -84,6 +84,8 @@ publishPage:
   latestversion: Laatste versie
   publishedversion: Publieke versie
   publish: Maak beschikbaar
+  notificationTitle: Geslaagd
+  notificationContent: Sjabloon beschikbaar gemaakt
 reglementaireBijlageTitel:
   description: "Titel reglementaire bijlage"
   placeholder: Naamloos document

--- a/translations/nl-BE.yaml
+++ b/translations/nl-BE.yaml
@@ -81,6 +81,8 @@ auth:
   logout: Afmelden
 publishPage:
   title: Maak reglementaire bijlage sjabloon beschikbaar
+  titleShort: Sjabloon beschikbaar maken
+  back: Terug naar reglementaire bijlage
   latestversion: Laatste versie
   publishedversion: Publieke versie
   publish: Maak beschikbaar


### PR DESCRIPTION
This PR includes two new features:
- The addition of a navigation bar on the publish page which allows a user to go back to the edit page.
- A notification is shown when the template has been successfully published.

This PR solves https://binnenland.atlassian.net/jira/software/c/projects/GN/boards/4?modal=detail&selectedIssue=GN-3768.