### PR TITLE
GN-3766 - The overview page of frontend-rb should be sorted by default

### DIFF
--- a/app/components/codelist-form.hbs
+++ b/app/components/codelist-form.hbs
@@ -85,7 +85,7 @@
               </th>
             </tr>
           </thead>
-          <SortableObjects @tagName={{"tbody"}} @sortableObjectList={{this.options}} @sortEndAction={{fn this.sortEndAction}} @enableSort={{true}} @useSwap={{true}} @inPlace={{true}}>
+          <SortableObjects @tagName={{"tbody"}} @sortableObjectList={{this.options}} @sortEndAction={{this.sortEndAction}} @enableSort={{true}} @useSwap={{true}} @inPlace={{true}}>
             {{#each this.options as |option|}}
               <DraggableObject @content={{option}} @tagName="tr" @isSortable={{true}}>
                 <td>

--- a/app/controllers/codelists-management/index.js
+++ b/app/controllers/codelists-management/index.js
@@ -6,9 +6,9 @@ export default class CodelistsManagementIndexController extends Controller {
   queryParams = ['page', 'size', 'label', 'sort'];
 
   @tracked page = 0;
-  @tracked size = 30;
+  @tracked size = 20;
   @tracked label = '';
-  @tracked sort = 'label';
+  @tracked sort = '-created-on';
 
   @restartableTask
   *updateSearchFilterTask(queryParamProperty, event) {

--- a/app/controllers/edit.js
+++ b/app/controllers/edit.js
@@ -31,7 +31,7 @@ export default class EditController extends Controller {
   @task
   *publish() {
     yield this.save.perform();
-    this.router.transitionTo('publish', this.model.reglement.id);
+    this.router.transitionTo('publish', this.model.documentContainer.id);
   }
 
   @task

--- a/app/controllers/list.js
+++ b/app/controllers/list.js
@@ -3,6 +3,7 @@ import { task } from 'ember-concurrency';
 import { inject as service } from '@ember/service';
 import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
+import { restartableTask, timeout } from 'ember-concurrency';
 import { RS_DELETED_FOLDER, RS_STANDARD_FOLDER } from '../utils/constants';
 
 export default class ListController extends Controller {
@@ -14,6 +15,7 @@ export default class ListController extends Controller {
 
   @tracked page = 0;
   @tracked size = 20;
+  @tracked title = '';
   @tracked debounceTime = 2000;
   @tracked editorDocument;
   @tracked documentContainer;
@@ -102,5 +104,17 @@ export default class ListController extends Controller {
   @action
   logout() {
     this.session.invalidate();
+  }
+
+  @restartableTask
+  *updateSearchFilterTask(queryParamProperty, event) {
+    yield timeout(300);
+
+    this[queryParamProperty] = event.target.value.trim();
+    this.resetPagination();
+  }
+
+  resetPagination() {
+    this.page = 0;
   }
 }

--- a/app/controllers/list.js
+++ b/app/controllers/list.js
@@ -3,13 +3,9 @@ import { task } from 'ember-concurrency';
 import { inject as service } from '@ember/service';
 import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
-// eslint-disable-next-line ember/no-mixins
-import DefaultQueryParamsMixin from 'ember-data-table/mixins/default-query-params';
 import { RS_DELETED_FOLDER, RS_STANDARD_FOLDER } from '../utils/constants';
 
-export default class ListController extends Controller.extend(
-  DefaultQueryParamsMixin
-) {
+export default class ListController extends Controller {
   @service store;
   @service session;
   @service router;

--- a/app/controllers/list.js
+++ b/app/controllers/list.js
@@ -3,6 +3,7 @@ import { task } from 'ember-concurrency';
 import { inject as service } from '@ember/service';
 import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
+// eslint-disable-next-line ember/no-mixins
 import DefaultQueryParamsMixin from 'ember-data-table/mixins/default-query-params';
 import { RS_DELETED_FOLDER, RS_STANDARD_FOLDER } from '../utils/constants';
 
@@ -15,11 +16,15 @@ export default class ListController extends Controller.extend(
   @service currentSession;
   @service muTask;
 
+  @tracked page = 0;
+  @tracked size = 20;
+  @tracked debounceTime = 2000;
   @tracked editorDocument;
   @tracked documentContainer;
   @tracked reglement;
   @tracked createReglementModalIsOpen;
   @tracked removeReglementModalIsOpen;
+  sort = '-document.current-version.updated-on';
 
   @action
   startCreateReglementFlow() {

--- a/app/controllers/list.js
+++ b/app/controllers/list.js
@@ -24,7 +24,7 @@ export default class ListController extends Controller.extend(
   @tracked reglement;
   @tracked createReglementModalIsOpen;
   @tracked removeReglementModalIsOpen;
-  sort = '-document.current-version.updated-on';
+  sort = '-document.current-version.created-on';
 
   @action
   startCreateReglementFlow() {

--- a/app/controllers/publish.js
+++ b/app/controllers/publish.js
@@ -21,12 +21,11 @@ export default class PublishController extends Controller {
   *fetchPreview() {
     this.currentVersion = '';
     const publishedVersionContainer =
-      yield this.model.reglement.publishedVersion.reload();
+      yield this.model.container.publishedVersion.reload();
     if (publishedVersionContainer) {
       const publishedVersion =
         yield publishedVersionContainer.currentVersion.reload();
-      const publishedVersionContent = yield publishedVersion.content;
-      const response = yield fetch(publishedVersionContent.downloadLink);
+      const response = yield fetch(publishedVersion.downloadLink);
       this.currentVersion = yield response.text();
     }
   }
@@ -37,7 +36,7 @@ export default class PublishController extends Controller {
     const publicationTask = this.store.createRecord(
       'regulatory-attachment-publication-task'
     );
-    publicationTask.regulatoryAttachment = this.model.reglement;
+    publicationTask.documentContainer = this.model.container;
     yield publicationTask.save();
     yield this.muTask.waitForMuTaskTask.perform(publicationTask.id, 100);
     yield this.fetchPreview.perform();

--- a/app/models/code-list.js
+++ b/app/models/code-list.js
@@ -1,7 +1,8 @@
-import { hasMany, belongsTo } from '@ember-data/model';
+import { attr, hasMany, belongsTo } from '@ember-data/model';
 import ConceptSchemeModel from './concept-scheme';
 
 export default class CodeListModel extends ConceptSchemeModel {
+  @attr('datetime') createdOn;
   @hasMany('mapping', { inverse: 'codeList' }) mappings;
   @belongsTo('skos-concept', { inverse: null }) type;
   @belongsTo('administrative-unit', { inverse: null }) publisher;

--- a/app/models/document-container.js
+++ b/app/models/document-container.js
@@ -7,4 +7,8 @@ export default class DocumentContainerModel extends Model {
   @belongsTo('editor-document-folder', { inverse: null }) folder;
   @belongsTo('administrative-unit', { inverse: null }) publisher;
   @hasMany('attachment', { inverse: 'documentContainer' }) attachments;
+  @belongsTo('published-regulatory-attachment-container', {
+    inverse: 'derivedFrom',
+  })
+  publishedVersion;
 }

--- a/app/models/editor-document.js
+++ b/app/models/editor-document.js
@@ -16,6 +16,10 @@ export default class EditorDocumentModel extends Model {
   nextVersion;
   @belongsTo('document-container', { inverse: 'revisions' })
   documentContainer;
+  @belongsTo('published-regulatory-attachment', {
+    inverse: 'derivedFrom',
+  })
+  publishedVersion;
 
   get htmlSafeContent() {
     return htmlSafe(this.content);

--- a/app/models/published-regulatory-attachment-container.js
+++ b/app/models/published-regulatory-attachment-container.js
@@ -1,6 +1,6 @@
-import Model, { attr, belongsTo } from '@ember-data/model';
+import Model, { belongsTo } from '@ember-data/model';
 
 export default class PublishedRegulatoryAttachmentContainer extends Model {
-  @attr validThrough;
   @belongsTo('published-regulatory-attachment') currentVersion;
+  @belongsTo('document-container') derivedFrom;
 }

--- a/app/models/published-regulatory-attachment.js
+++ b/app/models/published-regulatory-attachment.js
@@ -1,5 +1,14 @@
-import Model, { belongsTo } from '@ember-data/model';
+import Model, { attr, belongsTo } from '@ember-data/model';
 
 export default class PublishedRegulatoryAttachment extends Model {
-  @belongsTo('file') content;
+  @belongsTo('editor-document') derivedFrom;
+  @attr validThrough;
+  @attr name;
+  @attr format;
+  @attr size;
+  @attr extension;
+  @attr('datetime') created;
+  get downloadLink() {
+    return `/files/${this.id}/download?name=${this.name}`;
+  }
 }

--- a/app/models/regulatory-attachment-publication-task.js
+++ b/app/models/regulatory-attachment-publication-task.js
@@ -1,6 +1,6 @@
 import Model, { attr, belongsTo } from '@ember-data/model';
 
 export default class RegulatoryAttachmentPublicationTask extends Model {
-  @belongsTo('regulatory-statement') regulatoryAttachment;
+  @belongsTo('document-container') documentContainer;
   @attr status;
 }

--- a/app/models/regulatory-statement.js
+++ b/app/models/regulatory-statement.js
@@ -1,7 +1,0 @@
-import Model, { attr, belongsTo } from '@ember-data/model';
-
-export default class RegulatoryStatement extends Model {
-  @belongsTo('document-container') document;
-  @attr folder;
-  @belongsTo('published-regulatory-attachment-container') publishedVersion;
-}

--- a/app/router.js
+++ b/app/router.js
@@ -25,5 +25,4 @@ Router.map(function () {
     this.route('codelist', { path: '/:id' });
   });
   this.route('sparql');
-  
 });

--- a/app/routes/codelists-management/new.js
+++ b/app/routes/codelists-management/new.js
@@ -7,7 +7,9 @@ export default class CodelistsManagementNewRoute extends Route {
 
   model() {
     return hash({
-      newCodelist: this.store.createRecord('code-list'),
+      newCodelist: this.store.createRecord('code-list', {
+        createdOn: new Date(),
+      }),
     });
   }
 }

--- a/app/routes/edit.js
+++ b/app/routes/edit.js
@@ -9,21 +9,16 @@ export default class EditRoute extends Route {
   profile = 'draftDecisionsProfile';
 
   async model(params) {
-    const reglement = await this.store.findRecord(
-      'regulatory-statement',
-      params.id
-    );
-    const containerId = (await reglement.get('document')).id;
     const documentContainer = await this.store.findRecord(
       'document-container',
-      containerId
+      params.id
     );
     const documentId = (await documentContainer.currentVersion).id;
     const editorDocument = await this.store.findRecord(
       'editor-document',
       documentId
     );
-    return { reglement, documentContainer, editorDocument };
+    return { documentContainer, editorDocument };
   }
   beforeModel(transition) {
     this.session.requireAuthentication(transition, 'login');

--- a/app/routes/list.js
+++ b/app/routes/list.js
@@ -21,10 +21,10 @@ export default class ListRoute extends Route {
   async model(params) {
     const options = {
       filter: {
-        folder: RS_STANDARD_FOLDER,
+        folder: {
+          id: RS_STANDARD_FOLDER,
+        },
       },
-      include:
-        'document.current-version,published-version.current-version.content',
       sort: params.sort,
       page: {
         number: params.page,
@@ -33,10 +33,10 @@ export default class ListRoute extends Route {
     };
 
     if (params.title) {
-      options['filter[document][current-version][title]'] = params.title;
+      options['filter[current-version][title]'] = params.title;
     }
 
-    return await this.store.query('regulatory-statement', options);
+    return await this.store.query('document-container', options);
   }
 
   setupController(controller, model) {

--- a/app/routes/list.js
+++ b/app/routes/list.js
@@ -23,7 +23,8 @@ export default class ListRoute extends Route.extend(DataTableRouteMixin) {
   async model(params) {
     const reglements = await this.store.query('regulatory-statement', {
       filter: { folder: RS_STANDARD_FOLDER },
-      include: 'document.current-version',
+      include:
+        'document.current-version,published-version.current-version.content',
       sort: params.sort,
       page: {
         number: params.page,

--- a/app/routes/list.js
+++ b/app/routes/list.js
@@ -33,7 +33,7 @@ export default class ListRoute extends Route {
     };
 
     if (params.title) {
-      options.filter.title = params.title;
+      options['filter[document][current-version][title]'] = params.title;
     }
 
     return await this.store.query('regulatory-statement', options);

--- a/app/routes/list.js
+++ b/app/routes/list.js
@@ -1,10 +1,8 @@
 import Route from '@ember/routing/route';
 import { inject as service } from '@ember/service';
 import { RS_STANDARD_FOLDER } from '../utils/constants';
-// eslint-disable-next-line ember/no-mixins
-import DataTableRouteMixin from 'ember-data-table/mixins/route';
 
-export default class ListRoute extends Route.extend(DataTableRouteMixin) {
+export default class ListRoute extends Route {
   modelName = 'regulatory-statement';
   @service store;
   @service session;

--- a/app/routes/list.js
+++ b/app/routes/list.js
@@ -1,6 +1,7 @@
 import Route from '@ember/routing/route';
 import { inject as service } from '@ember/service';
 import { RS_STANDARD_FOLDER } from '../utils/constants';
+// eslint-disable-next-line ember/no-mixins
 import DataTableRouteMixin from 'ember-data-table/mixins/route';
 
 export default class ListRoute extends Route.extend(DataTableRouteMixin) {
@@ -24,6 +25,10 @@ export default class ListRoute extends Route.extend(DataTableRouteMixin) {
       filter: { folder: RS_STANDARD_FOLDER },
       include: 'document.current-version',
       sort: params.sort,
+      page: {
+        number: params.page,
+        size: params.size,
+      },
     });
     return reglements;
   }

--- a/app/routes/list.js
+++ b/app/routes/list.js
@@ -3,11 +3,11 @@ import { inject as service } from '@ember/service';
 import { RS_STANDARD_FOLDER } from '../utils/constants';
 
 export default class ListRoute extends Route {
-  modelName = 'regulatory-statement';
   @service store;
   @service session;
 
   queryParams = {
+    title: { refreshModel: true },
     page: { refreshModel: true },
     size: { refreshModel: true },
     sort: { refreshModel: true },
@@ -19,8 +19,10 @@ export default class ListRoute extends Route {
   }
 
   async model(params) {
-    const reglements = await this.store.query('regulatory-statement', {
-      filter: { folder: RS_STANDARD_FOLDER },
+    const options = {
+      filter: {
+        folder: RS_STANDARD_FOLDER,
+      },
       include:
         'document.current-version,published-version.current-version.content',
       sort: params.sort,
@@ -28,8 +30,13 @@ export default class ListRoute extends Route {
         number: params.page,
         size: params.size,
       },
-    });
-    return reglements;
+    };
+
+    if (params.title) {
+      options.filter.title = params.title;
+    }
+
+    return await this.store.query('regulatory-statement', options);
   }
 
   setupController(controller, model) {

--- a/app/routes/publish.js
+++ b/app/routes/publish.js
@@ -5,15 +5,14 @@ export default class PublishRoute extends Route {
   @service session;
 
   async model(params) {
-    const reglement = await this.store.findRecord(
-      'regulatory-statement',
+    const container = await this.store.findRecord(
+      'document-container',
       params.id,
       { reload: true }
     );
-    const document = await reglement.get('document');
-    const currentVersion = await document.get('currentVersion');
+    const currentVersion = await container.get('currentVersion');
     const templateVersion = await currentVersion.get('templateVersion');
-    return { reglement: reglement, templateVersion };
+    return { container, templateVersion };
   }
 
   beforeModel(transition) {

--- a/app/templates/codelists-management/index.hbs
+++ b/app/templates/codelists-management/index.hbs
@@ -71,8 +71,8 @@
         {{codelist.id}}
       </td>
       <td>
-        {{#if codelist.type.createdOn}}
-          {{codelist.type.createdOn}}
+        {{#if codelist.createdOn}}
+          {{detailed-date codelist.createdOn}}
         {{else}}
           {{t "codelist.attr.notFound"}}
         {{/if}}

--- a/app/templates/codelists-management/index.hbs
+++ b/app/templates/codelists-management/index.hbs
@@ -59,7 +59,11 @@
         @label={{t "codelist.attr.label"}}
       />
       <th>{{t "codelist.attr.id"}}</th>
-      <th>{{t "codelist.attr.createdOn"}}</th>
+      <AuDataTableThSortable
+        @field="createdOn"
+        @currentSorting={{this.sort}}
+        @label={{t "codelist.attr.createdOn"}}
+      />
       <th>{{t "codelist.attr.type"}}</th>
       <th></th>
     </c.header>

--- a/app/templates/codelists-management/index.hbs
+++ b/app/templates/codelists-management/index.hbs
@@ -59,6 +59,7 @@
         @label={{t "codelist.attr.label"}}
       />
       <th>{{t "codelist.attr.id"}}</th>
+      <th>{{t "codelist.attr.createdOn"}}</th>
       <th>{{t "codelist.attr.type"}}</th>
       <th></th>
     </c.header>
@@ -68,6 +69,13 @@
       </td>
       <td>
         {{codelist.id}}
+      </td>
+      <td>
+        {{#if codelist.type.createdOn}}
+          {{codelist.type.createdOn}}
+        {{else}}
+          {{t "codelist.attr.notFound"}}
+        {{/if}}
       </td>
       <td>
         {{#if codelist.type}}

--- a/app/templates/list.hbs
+++ b/app/templates/list.hbs
@@ -50,21 +50,21 @@
   </table.menu>
   <table.content as |c|>
     <c.header>
-      <AuDataTableThSortable @field="document.currentVersion.title" @currentSorting={{this.sort}} @label={{t 'reglementList.title'}} />
-      <AuDataTableThSortable @field="document.currentVersion.createdOn" @currentSorting={{this.sort}} @label={{t 'reglementList.createdOn'}} />
-      <AuDataTableThSortable @field="document.currentVersion.updatedOn" @currentSorting={{this.sort}} @label={{t 'reglementList.updatedOn'}} />
-      <AuDataTableThSortable @field="document.currentVersion.title" @currentSorting={{this.sort}} @label={{t 'reglementList.publishDate'}} />
+      <AuDataTableThSortable @field="currentVersion.title" @currentSorting={{this.sort}} @label={{t 'reglementList.title'}} />
+      <AuDataTableThSortable @field="currentVersion.createdOn" @currentSorting={{this.sort}} @label={{t 'reglementList.createdOn'}} />
+      <AuDataTableThSortable @field="currentVersion.updatedOn" @currentSorting={{this.sort}} @label={{t 'reglementList.updatedOn'}} />
+      <AuDataTableThSortable @field="publishedVersion.currentVersion.created" @currentSorting={{this.sort}} @label={{t 'reglementList.publishDate'}} />
       <th></th>
     </c.header>
-    <c.body as |reglement|>
+    <c.body as |documentContainer|>
       <td>
-        <LinkTo @route="edit" @model={{reglement.id}} class="au-c-link">{{reglement.document.currentVersion.title}}</LinkTo>
+        <LinkTo @route="edit" @model={{documentContainer.id}} class="au-c-link">{{documentContainer.currentVersion.title}}</LinkTo>
       </td>
-      <td>{{detailed-date reglement.document.currentVersion.createdOn}}</td>
-      <td>{{detailed-date reglement.document.currentVersion.updatedOn}}</td>
+      <td>{{detailed-date documentContainer.currentVersion.createdOn}}</td>
+      <td>{{detailed-date documentContainer.currentVersion.updatedOn}}</td>
       <td>
-        {{#if reglement.publishedVersion.currentVersion.content.created}}
-          {{ detailed-date reglement.publishedVersion.currentVersion.content.created }}
+        {{#if documentContainer.publishedVersion.currentVersion.created}}
+          {{ detailed-date documentContainer.publishedVersion.currentVersion.created }}
         {{else}}
           {{t "reglementList.notFound"}}
         {{/if}}
@@ -75,7 +75,7 @@
           @alert={{true}}
           @skin="secondary"
           @hideText={{true}}
-          {{on "click" (fn this.startRemoveReglementFlow reglement)}}
+          {{on "click" (fn this.startRemoveReglementFlow documentContainer)}}
         >
           {{t "utility.delete"}}
         </AuButton>

--- a/app/templates/list.hbs
+++ b/app/templates/list.hbs
@@ -46,7 +46,7 @@
       <th></th>
     </c.header>
     <c.body as |reglement|>
-      <td>Publish date tes: {{ publishedVersion.currentVersion.content.created }}</td>
+      <td>Publish date test: {{ publishedVersion.currentVersion.content.created }}</td>
       <td>
         <LinkTo @route="edit" @model={{reglement.id}} class="au-c-link">{{reglement.document.currentVersion.title}}</LinkTo>
       </td>

--- a/app/templates/list.hbs
+++ b/app/templates/list.hbs
@@ -39,12 +39,14 @@
   </table.menu>
   <table.content as |c|>
     <c.header>
+      <th>Publish Date</th>
       <AuDataTableThSortable @field="document.currentVersion.title" @currentSorting={{this.sort}} @label={{t 'reglementList.title'}} />
       <AuDataTableThSortable @field="document.currentVersion.createdOn" @currentSorting={{this.sort}} @label={{t 'reglementList.createdOn'}} />
       <AuDataTableThSortable @field="document.currentVersion.updatedOn" @currentSorting={{this.sort}} @label={{t 'reglementList.updatedOn'}} />
       <th></th>
     </c.header>
     <c.body as |reglement|>
+      <td>Publish date tes: {{ publishedVersion.currentVersion.content.created }}</td>
       <td>
         <LinkTo @route="edit" @model={{reglement.id}} class="au-c-link">{{reglement.document.currentVersion.title}}</LinkTo>
       </td>

--- a/app/templates/list.hbs
+++ b/app/templates/list.hbs
@@ -30,6 +30,17 @@
           </AuHeading>
         </AuToolbarGroup>
         <AuToolbarGroup class="au-c-toolbar__group--center">
+          <div class="au-c-data-table__search codelist-label-search">
+            <input
+              value={{this.title}}
+              placeholder={{t "reglementList.crud.labelFilter"}}
+              class="au-c-input au-c-input--block"
+              {{on "input" (perform this.updateSearchFilterTask "title")}}
+            />
+            <span class="au-c-data-table__search-icon">
+              <AuIcon @icon="search" @size="large" />
+            </span>
+          </div>
           {{#unless this.readOnly}}
             <AuButton @icon="add" @iconAlignment="left"  {{on 'click' this.startCreateReglementFlow}}>{{t "reglementList.new"}}</AuButton>
           {{/unless}}

--- a/app/templates/list.hbs
+++ b/app/templates/list.hbs
@@ -39,19 +39,25 @@
   </table.menu>
   <table.content as |c|>
     <c.header>
-      <th>Publish Date</th>
       <AuDataTableThSortable @field="document.currentVersion.title" @currentSorting={{this.sort}} @label={{t 'reglementList.title'}} />
       <AuDataTableThSortable @field="document.currentVersion.createdOn" @currentSorting={{this.sort}} @label={{t 'reglementList.createdOn'}} />
       <AuDataTableThSortable @field="document.currentVersion.updatedOn" @currentSorting={{this.sort}} @label={{t 'reglementList.updatedOn'}} />
+      <AuDataTableThSortable @field="document.currentVersion.title" @currentSorting={{this.sort}} @label={{t 'reglementList.publishDate'}} />
       <th></th>
     </c.header>
     <c.body as |reglement|>
-      <td>Publish date test: {{ publishedVersion.currentVersion.content.created }}</td>
       <td>
         <LinkTo @route="edit" @model={{reglement.id}} class="au-c-link">{{reglement.document.currentVersion.title}}</LinkTo>
       </td>
       <td>{{detailed-date reglement.document.currentVersion.createdOn}}</td>
       <td>{{detailed-date reglement.document.currentVersion.updatedOn}}</td>
+      <td>
+        {{#if reglement.publishedVersion.currentVersion.content.created}}
+          {{ detailed-date reglement.publishedVersion.currentVersion.content.created }}
+        {{else}}
+          {{t "reglementList.notFound"}}
+        {{/if}}
+      </td>
       <td>
         <AuButton
           @icon="bin"

--- a/app/templates/list.hbs
+++ b/app/templates/list.hbs
@@ -14,7 +14,13 @@
     </ul>
   </Group>
 </AuToolbar>
-<AuDataTable @content={{this.model}} @isLoading={{this.isLoadingModel}} @noDataMessage={{t 'reglementList.noDataMessage'}} @sort={{this.sort}} @page={{this.page}} @size={{this.size}} as |table|>
+<AuDataTable
+  @content={{this.model}}
+  @isLoading={{this.isLoadingModel}}
+  @noDataMessage={{t 'reglementList.noDataMessage'}}
+  @sort={{this.sort}}
+  @page={{this.page}}
+  @size={{this.size}} as |table|>
   <table.menu as |menu|>
     <menu.general>
       <AuToolbar class="au-o-box" @size="large">
@@ -33,8 +39,9 @@
   </table.menu>
   <table.content as |c|>
     <c.header>
-      <th><span class="au-c-data-table__header-title au-c-data-table__header-title--sortable">{{t 'reglementList.title'}}</span></th>
+      <AuDataTableThSortable @field="document.currentVersion.title" @currentSorting={{this.sort}} @label={{t 'reglementList.title'}} />
       <AuDataTableThSortable @field="document.currentVersion.createdOn" @currentSorting={{this.sort}} @label={{t 'reglementList.createdOn'}} />
+      <AuDataTableThSortable @field="document.currentVersion.updatedOn" @currentSorting={{this.sort}} @label={{t 'reglementList.updatedOn'}} />
       <th></th>
     </c.header>
     <c.body as |reglement|>
@@ -42,6 +49,7 @@
         <LinkTo @route="edit" @model={{reglement.id}} class="au-c-link">{{reglement.document.currentVersion.title}}</LinkTo>
       </td>
       <td>{{detailed-date reglement.document.currentVersion.createdOn}}</td>
+      <td>{{detailed-date reglement.document.currentVersion.updatedOn}}</td>
       <td>
         <AuButton
           @icon="bin"

--- a/app/templates/publish.hbs
+++ b/app/templates/publish.hbs
@@ -3,7 +3,7 @@
   <Group>
     <ul class="au-c-list-horizontal au-c-list-horizontal--small">
       <li class="au-c-list-horizontal__item">
-        <AuLink @linkRoute="edit" @model={{model.reglement.id}} >
+        <AuLink @linkRoute="edit" @model={{model.container.id}} >
           <AuIcon @icon="arrow-left" @alignment="left" />
           {{t "publishPage.back"}}
         </AuLink>

--- a/config/environment.js
+++ b/config/environment.js
@@ -36,13 +36,12 @@ module.exports = function (environment) {
     },
     environmentName: '{{ENVIRONMENT_NAME}}',
     insertVariablePlugin: {
-      endpoint: '{{VARIABLE_PLUGIN_ENDPOINT}}'
-    }
+      endpoint: '{{VARIABLE_PLUGIN_ENDPOINT}}',
+    },
   };
 
-
   if (environment === 'development') {
-    ENV.insertVariablePlugin.endpoint =  '/raw-sparql';
+    ENV.insertVariablePlugin.endpoint = '/raw-sparql';
     // ENV.APP.LOG_RESOLVER = true;
     // ENV.APP.LOG_ACTIVE_GENERATION = true;
     // ENV.APP.LOG_TRANSITIONS = true;

--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -15,6 +15,8 @@ codelist:
   attr:
     label: Label
     type: Type
+    createdOn: Created On
+    notFound: N/A
     options: "Options"
     option:
       value: Value
@@ -63,6 +65,8 @@ reglementList:
   title: Title
   createdOn: Created On
   updatedOn: Updated On
+  notFound: N/A
+  publishDate: Publish Date
   noDataMessage: No Data
   createModal:
     title: Create new regulatory attachment

--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -62,6 +62,7 @@ reglementList:
   new: Add new
   title: Title
   createdOn: Created On
+  updatedOn: Updated On
   noDataMessage: No Data
   createModal:
     title: Create new regulatory attachment

--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -66,7 +66,7 @@ reglementList:
   createdOn: Created On
   updatedOn: Updated On
   notFound: N/A
-  publishDate: Publish Date
+  publishDate: Published on
   noDataMessage: No Data
   createModal:
     title: Create new regulatory attachment

--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -68,6 +68,8 @@ reglementList:
   notFound: N/A
   publishDate: Published on
   noDataMessage: No Data
+  crud:
+    labelFilter: Label
   createModal:
     title: Create new regulatory attachment
     save: Save

--- a/translations/nl-BE.yaml
+++ b/translations/nl-BE.yaml
@@ -14,6 +14,8 @@ codelist:
   attr:
     label: Label
     type: Type
+    createdOn: Aangemaakt op
+    notFound: N/A
     options: "Items"
     option:
       value: Waarde
@@ -62,6 +64,8 @@ reglementList:
   title: Titel
   createdOn: Aangemaakt op
   updatedOn: Bijgewerkt op
+  notFound: N/A
+  publishDate: Publicatie datum
   noDataMessage: Geen bijlagen gevonden
   createModal:
     title: Een nieuwe reglementaire bijlage aanmaken

--- a/translations/nl-BE.yaml
+++ b/translations/nl-BE.yaml
@@ -61,6 +61,7 @@ reglementList:
   new: Aanmaken
   title: Titel
   createdOn: Aangemaakt op
+  updatedOn: Bijgewerkt op
   noDataMessage: Geen bijlagen gevonden
   createModal:
     title: Een nieuwe reglementaire bijlage aanmaken

--- a/translations/nl-BE.yaml
+++ b/translations/nl-BE.yaml
@@ -67,6 +67,8 @@ reglementList:
   notFound: n.v.t.
   publishDate: Beschikbaar gemaakt op
   noDataMessage: Geen bijlagen gevonden
+  crud:
+    labelFilter: Label
   createModal:
     title: Een nieuwe reglementaire bijlage aanmaken
     save: Opslaan

--- a/translations/nl-BE.yaml
+++ b/translations/nl-BE.yaml
@@ -15,7 +15,7 @@ codelist:
     label: Label
     type: Type
     createdOn: Aangemaakt op
-    notFound: N/A
+    notFound: n.v.t.
     options: "Items"
     option:
       value: Waarde
@@ -64,8 +64,8 @@ reglementList:
   title: Titel
   createdOn: Aangemaakt op
   updatedOn: Bijgewerkt op
-  notFound: N/A
-  publishDate: Publicatie datum
+  notFound: n.v.t.
+  publishDate: Beschikbaar gemaakt op
   noDataMessage: Geen bijlagen gevonden
   createModal:
     title: Een nieuwe reglementaire bijlage aanmaken


### PR DESCRIPTION
I added to the list page of regulatory statements, following functionalities:
    - sort on modified date by default
    - include the modified and published dates
    - allow filtering on title
    - support pagination

Please let me know If I'm missing something? Thanks