### PR TITLE
Update human-friendly date to accept a specific locale

### DIFF
--- a/app/components/app-chrome.hbs
+++ b/app/components/app-chrome.hbs
@@ -15,7 +15,7 @@
           {{#if @editorDocument.updatedOn}}
           <li class="au-c-list-horizontal__item">
             <span class="au-c-app-chrome__status">
-              {{t "utility.savedOn"}} {{human-friendly-date @editorDocument.updatedOn}}
+              {{t "utility.savedOn"}} {{human-friendly-date @editorDocument.updatedOn locale=this.intl.primaryLocale}}
             </span>
           </li>
           {{else}}

--- a/app/components/app-chrome.js
+++ b/app/components/app-chrome.js
@@ -5,6 +5,7 @@ import { action } from '@ember/object';
 export default class AppChromeComponent extends Component {
   @service currentSession;
   @service features;
+  @service intl;
 
   get documentStatus() {
     const status = this.args.documentContainer?.get('status');

--- a/app/helpers/human-friendly-date.js
+++ b/app/helpers/human-friendly-date.js
@@ -1,18 +1,18 @@
-import { helper } from '@ember/component/helper';
 import formatRelative from 'date-fns/formatRelative';
-import { nl } from 'date-fns/locale';
+import locales from 'date-fns/locale';
 
-// this is a helper to mimic the moment-calendar behaviour
-export default helper(function humanFriendlyDate(
-  [referenceDatetime] /*, hash*/
-) {
-  //If not a date (e.g. date is undefined) return "" for printing on screen.
-  if (!(referenceDatetime instanceof Date)) return '';
+function getDateFnsLocale(locale) {
+  return locales[locale] ?? locales[locale.substring(0, 2)];
+}
 
+export default function humanFriendlyDate(date, { locale = 'nl-BE' }) {
+  if (!(date instanceof Date)) return '';
   try {
-    return formatRelative(referenceDatetime, new Date(), { locale: nl });
+    return formatRelative(date, new Date(), {
+      locale: getDateFnsLocale(locale),
+    });
   } catch (e) {
     console.error(e);
     return '';
   }
-});
+}

--- a/app/helpers/human-friendly-date.js
+++ b/app/helpers/human-friendly-date.js
@@ -5,7 +5,7 @@ function getDateFnsLocale(locale) {
   return locales[locale] ?? locales[locale.substring(0, 2)];
 }
 
-export default function humanFriendlyDate(date, { locale = 'nl-BE' }) {
+export default function humanFriendlyDate(date, { locale = 'nl-BE' } = {}) {
   if (!(date instanceof Date)) return '';
   try {
     return formatRelative(date, new Date(), {


### PR DESCRIPTION
This PR ensures that we can show human-readable dates in the current locale of the user.
Solves https://binnenland.atlassian.net/browse/GN-3944?atlOrigin=eyJpIjoiMDY0ODBlNjUzMzkzNDkyNWEwZDAwNWRjMTQ4YzE5MGIiLCJwIjoiaiJ9.