### PR TITLE
Internal/prevent hardcoded strings

### DIFF
--- a/.template-lintrc.js
+++ b/.template-lintrc.js
@@ -2,4 +2,7 @@
 
 module.exports = {
   extends: 'recommended',
+  rules: {
+    'no-bare-strings': true,
+  },
 };

--- a/app/components/codelist-form.hbs
+++ b/app/components/codelist-form.hbs
@@ -64,7 +64,7 @@
           @onChange={{this.updateCodelistType}}
           as |type|
         >
-          <span style="margin: 20px">{{t
+          <span class="codelist-type-select-option">{{t
               (concat "codelist.attr.types." type.label)
             }}</span>
         </PowerSelect>
@@ -74,7 +74,7 @@
         <table class="au-c-data-table__table">
           <thead>
             <tr class="au-c-data-table__header">
-              <th class="data-table__header-title" style="width: 100px;">{{t "codelist.orderLabel"}}</th>
+              <th class="data-table__header-title codelist-order-header">{{t "codelist.orderLabel"}}</th>
               <th class="data-table__header-title" >
                 {{t "codelist.attr.options"}}
               </th>
@@ -89,9 +89,7 @@
             {{#each this.options as |option|}}
               <DraggableObject @content={{option}} @tagName="tr" @isSortable={{true}}>
                 <td>
-                  <AuButton @icon="drag" @skin="tertiary" @hideText={{true}} class="au-c-button--drag">
-                    Sleep
-                  </AuButton>
+                  <AuButton @icon="drag" @skin="tertiary" @hideText={{true}} class="au-c-button--drag"></AuButton>
                 </td>
                 <td>
                   <p class="max-w-prose">

--- a/app/components/codelist-form.hbs
+++ b/app/components/codelist-form.hbs
@@ -1,3 +1,4 @@
+{{!-- template-lint-disable table-groups  --}}
 {{#let (changeset @codelist this.CodelistValidations) as |codelist|}}
   <BreadcrumbsItem as |linkClass|>
     {{#if @codelist.isNew}}

--- a/app/components/editor-document-title.hbs
+++ b/app/components/editor-document-title.hbs
@@ -39,7 +39,7 @@
         @icon="pencil"
         @skin="tertiary"
         @hideText={{true}}
-      >titel wijzigen</AuButton>
+      >{{t "reglementaireBijlageTitel.modify"}}</AuButton>
     </h1>
   {{/if}}
 

--- a/app/components/static-page.hbs
+++ b/app/components/static-page.hbs
@@ -8,25 +8,24 @@
 
 <AuMainFooter>
   <AuHeading @level="3" @skin="4">
-    reglementaire-bijlage.vlaanderen.be is een officiële website van de Vlaamse
-    overheid
+    {{t "static-page.official-website"}}
   </AuHeading>
   <AuContent @skin="small">
-    <p>Uitgegeven door
+    <p>{{t "static-page.published-by"}}
       <a
         class="au-c-link"
         href="https://www.vlaanderen.be/organisaties/administratieve-diensten-van-de-vlaamse-overheid/beleidsdomein-kanselarij-en-bestuur/agentschap-binnenlands-bestuur"
-      >Agentschap Binnenlands Bestuur</a>
+      >{{t "static-page.agentschap-binnenlands-bestuur"}}</a>
     </p>
     <ul class="au-c-list-horizontal">
       <li class="au-c-list-horizontal__item">
-        <AuLink @route="legal.disclaimer" @skin="secondary">Disclaimer</AuLink>
+        <AuLink @route="legal.disclaimer" @skin="secondary">{{t "static-page.disclaimer"}}</AuLink>
       </li>
       <li class="au-c-list-horizontal__item">
-        <AuLink @route="legal.cookiestatement" @skin="secondary">Cookieverklaring</AuLink>
+        <AuLink @route="legal.cookiestatement" @skin="secondary">{{t "static-page.cookie-policy"}}</AuLink>
       </li>
       <li class="au-c-list-horizontal__item">
-        <AuLink @route="legal.accessibilitystatement" @skin="secondary">Toegankelijkheidsverklaring</AuLink>
+        <AuLink @route="legal.accessibilitystatement" @skin="secondary">{{t "static-page.accesibility-statement"}}</AuLink>
       </li>
     </ul>
   </AuContent>

--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -76,3 +76,11 @@ div.table-of-contents {
   max-height: 500px;
   overflow: auto;
 }
+
+.codelist-order-header {
+  width: 100px;
+} 
+
+.codelist-type-select-option {
+  margin: 20px;
+}

--- a/app/templates/application.hbs
+++ b/app/templates/application.hbs
@@ -20,7 +20,7 @@
     </AuDropdown>
     {{else}}
         <AuLink @route="login">
-          Login
+          {{t "auth.login"}}
         </AuLink>
     {{/if}}
   </AuMainHeader>

--- a/app/templates/codelists-management/index.hbs
+++ b/app/templates/codelists-management/index.hbs
@@ -34,6 +34,7 @@
           <div class="au-c-data-table__search codelist-label-search">
             <input
               value={{this.label}}
+              aria-label={{t "codelist.crud.labelFilter"}}
               placeholder={{t "codelist.crud.labelFilter"}}
               class="au-c-input au-c-input--block"
               {{on "input" (perform this.updateSearchFilterTask "label")}}

--- a/app/templates/list.hbs
+++ b/app/templates/list.hbs
@@ -32,6 +32,7 @@
         <AuToolbar::Group class="au-c-toolbar__group--center">
           <div class="au-c-data-table__search codelist-label-search">
             <input
+              aria-label={{t "reglementList.crud.labelFilter"}}
               value={{this.title}}
               placeholder={{t "reglementList.crud.labelFilter"}}
               class="au-c-input au-c-input--block"
@@ -91,12 +92,10 @@
 >
   <Modal.Body>
     <form class="au-o-flow" id="create-meeting-form" {{on "submit" (perform this.saveReglement)}}>
-      <AuLabel
-        for={{id}}
-      >
+      <AuLabel for="reglementList-title">
         {{t "reglementList.title"}}
       </AuLabel>
-      <AuInput @value={{this.editorDocument.title}} @width="block" id={{id}} type="text" />
+      <AuInput @value={{this.editorDocument.title}} @width="block" id="reglementList-title" type="text" />
     </form>
   </Modal.Body>
   <Modal.Footer>

--- a/app/templates/publish.hbs
+++ b/app/templates/publish.hbs
@@ -1,3 +1,4 @@
+{{!-- template-lint-disable no-triple-curlies  --}}
 {{page-title 'Publish'}}
 <AuToolbar @size="small" class="au-u-padding-bottom-none" as |Group|>
   <Group>

--- a/app/templates/publish.hbs
+++ b/app/templates/publish.hbs
@@ -3,7 +3,7 @@
   <Group>
     <ul class="au-c-list-horizontal au-c-list-horizontal--small">
       <li class="au-c-list-horizontal__item">
-        <AuLink @route="edit" @model={{model.container.id}} >
+        <AuLink @route="edit" @model={{this.model.container.id}} >
           <AuIcon @icon="arrow-left" @alignment="left" />
           {{t "publishPage.back"}}
         </AuLink>

--- a/app/templates/publish.hbs
+++ b/app/templates/publish.hbs
@@ -1,5 +1,5 @@
 {{!-- template-lint-disable no-triple-curlies  --}}
-{{page-title 'Publish'}}
+{{page-title (t "publish-page.title-short")}}
 <AuToolbar @size="small" class="au-u-padding-bottom-none" as |Group|>
   <Group>
     <ul class="au-c-list-horizontal au-c-list-horizontal--small">

--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -84,6 +84,7 @@ reglementEdit:
   saving: Saving
   confirmLeaveWithoutSaving: Are you sure you would like to leave this page without saving your changes?
 auth:
+  login: Login
   acmidm: Log in with acm/idm
   mock:
     selectUser: Choose a mock user

--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -107,4 +107,4 @@ static-page:
   agentschap-binnenlands-bestuur: Agentschap Binnenlands Bestuur
   disclaimer: Disclaimer
   cookie-policy: Cookie Policy
-  accesibility-statement: Accesibility Statement
+  accesibility-statement: Accessibility Statement

--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -101,3 +101,10 @@ reglementaire-bijlage-titel:
   description: "Regulatory statement title"
   placeholder: "Untitled document"
   modify: "Modify title"
+static-page:
+  official-website: reglementaire-bijlage.vlaanderen.be is an official website of the Flemish government
+  published-by: Published by
+  agentschap-binnenlands-bestuur: Agentschap Binnenlands Bestuur
+  disclaimer: Disclaimer
+  cookie-policy: Cookie Policy
+  accesibility-statement: Accesibility Statement

--- a/translations/nl-BE.yaml
+++ b/translations/nl-BE.yaml
@@ -101,3 +101,10 @@ reglementaire-bijlage-titel:
   description: "Titel reglementaire bijlage"
   placeholder: Naamloos document
   modify: "Titel aanpassen"
+static-page:
+  official-website: reglementaire-bijlage.vlaanderen.be is een officiële website van de Vlaamse overheid
+  published-by: Uitgegeven door
+  agentschap-binnenlands-bestuur: Agentschap Binnenlands Bestuur
+  disclaimer: Disclaimer
+  cookie-policy: Cookieverklaring
+  accesibility-statement: Toegankelijkheidsverklaring

--- a/translations/nl-BE.yaml
+++ b/translations/nl-BE.yaml
@@ -75,7 +75,7 @@ reglement-list:
     cancel: Terug
   remove-modal:
     title:  Weet u zeker dat u deze reglementaire bijlage wilt verwijderen?
-    remove: Remove
+    remove: Bijlage verwijderen
     cancel: Terug
 reglement-edit:
   edit: Wijzig bijlage

--- a/translations/nl-BE.yaml
+++ b/translations/nl-BE.yaml
@@ -84,6 +84,7 @@ reglementEdit:
   saving: Bezig met opslaan
   confirmLeaveWithoutSaving: Bent u zeker dat u deze pagina wilt verlaten zonder uw wijzigingen op te slaan?
 auth:
+  login: Login
   acmidm: Log in met acm/idm
   mock:
     selectUser: Selecteer een testgebruiker


### PR DESCRIPTION
Added a template-lint rule and fixed the problems that appeared, now we can use the template linting to catch future mistakes.