### PR TITLE
Remove/replace deprecated code

### DIFF
--- a/app/adapters/application.js
+++ b/app/adapters/application.js
@@ -1,0 +1,3 @@
+import JSONAPIAdapter from '@ember-data/adapter/json-api';
+
+export default class ApplicationAdapter extends JSONAPIAdapter {}

--- a/app/components/codelist-form.js
+++ b/app/components/codelist-form.js
@@ -30,7 +30,7 @@ export default class CodelistFormComponent extends Component {
 
   @action
   async didInsert() {
-    const concepts = (await this.args.codelist.concepts).toArray();
+    const concepts = (await this.args.codelist.concepts).slice();
     this.options = concepts.sort((a, b) => {
       if (!a.position && !b.position) {
         return 0;

--- a/app/controllers/codelists-management/codelist.js
+++ b/app/controllers/codelists-management/codelist.js
@@ -10,7 +10,7 @@ export default class CodelistController extends Controller {
 
   @action
   async didInsert() {
-    const concepts = (await this.model.codelist.concepts).toArray();
+    const concepts = (await this.model.codelist.concepts).slice();
     this.options = concepts.sort((a, b) => {
       if (!a.position && !b.position) {
         return 0;

--- a/app/controllers/mock-login.js
+++ b/app/controllers/mock-login.js
@@ -33,4 +33,9 @@ export default class MockLoginController extends Controller {
     this.municipality = value;
     this.model = await this.queryStore.perform();
   });
+
+  getGroup = async (account) => {
+    const user = await account.user;
+    return (await user.groups)[0];
+  };
 }

--- a/app/models/account.js
+++ b/app/models/account.js
@@ -3,5 +3,5 @@ import Model, { attr, belongsTo } from '@ember-data/model';
 export default class AccountModel extends Model {
   @attr voId;
   @attr provider;
-  @belongsTo('user', { inverse: null }) user;
+  @belongsTo('user', { inverse: null, async: true }) user;
 }

--- a/app/models/administrative-unit.js
+++ b/app/models/administrative-unit.js
@@ -3,9 +3,13 @@ import Model, { attr, belongsTo, hasMany } from '@ember-data/model';
 export default class AdministrativeUnitModel extends Model {
   @attr name;
   @attr uri;
-  @belongsTo('administrative-unit-classification-code', { inverse: null })
+  @belongsTo('administrative-unit-classification-code', {
+    inverse: null,
+    async: true,
+  })
   classification;
-  @hasMany('governing-body', { inverse: 'administrativeUnit' }) governingBody;
+  @hasMany('governing-body', { inverse: 'administrativeUnit', async: true })
+  governingBody;
 
   rdfaBindings = {
     naam: 'http://www.w3.org/2004/02/skos/core#prefLabel',

--- a/app/models/attachment.js
+++ b/app/models/attachment.js
@@ -2,8 +2,8 @@ import Model, { attr, belongsTo } from '@ember-data/model';
 
 export default class AttachmentModel extends Model {
   @attr decision;
-  @belongsTo('concept', { inverse: null }) type;
-  @belongsTo('document-container', { inverse: 'attachments' })
+  @belongsTo('concept', { inverse: null, async: true }) type;
+  @belongsTo('document-container', { inverse: 'attachments', async: true })
   documentContainer;
-  @belongsTo('file', { inverse: null }) file;
+  @belongsTo('file', { inverse: null, async: true }) file;
 }

--- a/app/models/code-list.js
+++ b/app/models/code-list.js
@@ -3,7 +3,7 @@ import ConceptSchemeModel from './concept-scheme';
 
 export default class CodeListModel extends ConceptSchemeModel {
   @attr('datetime') createdOn;
-  @hasMany('mapping', { inverse: 'codeList' }) mappings;
-  @belongsTo('skos-concept', { inverse: null }) type;
-  @belongsTo('administrative-unit', { inverse: null }) publisher;
+  @hasMany('mapping', { inverse: 'codeList', async: true }) mappings;
+  @belongsTo('skos-concept', { inverse: null, async: true }) type;
+  @belongsTo('administrative-unit', { inverse: null, async: true }) publisher;
 }

--- a/app/models/concept-scheme.js
+++ b/app/models/concept-scheme.js
@@ -2,5 +2,5 @@ import Model, { attr, hasMany } from '@ember-data/model';
 
 export default class ConceptScheme extends Model {
   @attr label;
-  @hasMany('skos-concept', { inverse: 'inScheme' }) concepts;
+  @hasMany('skos-concept', { inverse: 'inScheme', async: true }) concepts;
 }

--- a/app/models/concept-scheme.js
+++ b/app/models/concept-scheme.js
@@ -2,5 +2,10 @@ import Model, { attr, hasMany } from '@ember-data/model';
 
 export default class ConceptScheme extends Model {
   @attr label;
-  @hasMany('skos-concept', { inverse: 'inScheme', async: true }) concepts;
+  @hasMany('skos-concept', {
+    inverse: 'inScheme',
+    async: true,
+    as: 'concept-scheme',
+  })
+  concepts;
 }

--- a/app/models/concept.js
+++ b/app/models/concept.js
@@ -4,6 +4,6 @@ export default class ConceptModel extends Model {
   @attr uri;
   @attr label;
 
-  @hasMany('concept-scheme', { inverse: null }) conceptSchemes;
-  @hasMany('concept-scheme', { inverse: null }) topConceptSchemes;
+  @hasMany('concept-scheme', { inverse: null, async: true }) conceptSchemes;
+  @hasMany('concept-scheme', { inverse: null, async: true }) topConceptSchemes;
 }

--- a/app/models/document-container.js
+++ b/app/models/document-container.js
@@ -1,14 +1,17 @@
 import Model, { belongsTo, hasMany } from '@ember-data/model';
 
 export default class DocumentContainerModel extends Model {
-  @hasMany('editor-document', { inverse: 'documentContainer' }) revisions;
-  @belongsTo('editor-document', { inverse: null }) currentVersion;
-  @belongsTo('skos-concept', { inverse: null }) status;
-  @belongsTo('editor-document-folder', { inverse: null }) folder;
-  @belongsTo('administrative-unit', { inverse: null }) publisher;
-  @hasMany('attachment', { inverse: 'documentContainer' }) attachments;
+  @hasMany('editor-document', { inverse: 'documentContainer', async: true })
+  revisions;
+  @belongsTo('editor-document', { inverse: null, async: true }) currentVersion;
+  @belongsTo('skos-concept', { inverse: null, async: true }) status;
+  @belongsTo('editor-document-folder', { inverse: null, async: true }) folder;
+  @belongsTo('administrative-unit', { inverse: null, async: true }) publisher;
+  @hasMany('attachment', { inverse: 'documentContainer', async: true })
+  attachments;
   @belongsTo('published-regulatory-attachment-container', {
     inverse: 'derivedFrom',
+    async: true,
   })
   publishedVersion;
 }

--- a/app/models/editor-document.js
+++ b/app/models/editor-document.js
@@ -10,14 +10,15 @@ export default class EditorDocumentModel extends Model {
   @attr('string', { defaultValue: defaultContext }) context;
   @attr('datetime') createdOn;
   @attr('datetime') updatedOn;
-  @belongsTo('editor-document', { inverse: 'nextVersion' })
+  @belongsTo('editor-document', { inverse: 'nextVersion', async: true })
   previousVersion;
-  @belongsTo('editor-document', { inverse: 'previousVersion' })
+  @belongsTo('editor-document', { inverse: 'previousVersion', async: true })
   nextVersion;
-  @belongsTo('document-container', { inverse: 'revisions' })
+  @belongsTo('document-container', { inverse: 'revisions', async: true })
   documentContainer;
   @belongsTo('published-regulatory-attachment', {
     inverse: 'derivedFrom',
+    async: true,
   })
   publishedVersion;
 

--- a/app/models/governing-body.js
+++ b/app/models/governing-body.js
@@ -5,7 +5,7 @@ export default class GoverningBodyModel extends Model {
   @attr naam;
   @attr('date') bindingEinde;
   @attr('date') bindingStart;
-  @belongsTo('administrative-unit', { inverse: 'governing-body', async: true })
+  @belongsTo('administrative-unit', { inverse: 'governingBody', async: true })
   adminstrativeUnit;
   @belongsTo('administrative-unit-classification-code', {
     inverse: null,

--- a/app/models/governing-body.js
+++ b/app/models/governing-body.js
@@ -5,13 +5,19 @@ export default class GoverningBodyModel extends Model {
   @attr naam;
   @attr('date') bindingEinde;
   @attr('date') bindingStart;
-  @belongsTo('administrative-unit', { inverse: 'governing-body' })
+  @belongsTo('administrative-unit', { inverse: 'governing-body', async: true })
   adminstrativeUnit;
-  @belongsTo('administrative-unit-classification-code', { inverse: null })
+  @belongsTo('administrative-unit-classification-code', {
+    inverse: null,
+    async: true,
+  })
   classification;
-  @belongsTo('governing-body', { inverse: 'hasTimeSpecializations' })
+  @belongsTo('governing-body', {
+    inverse: 'hasTimeSpecializations',
+    async: true,
+  })
   isTimeSpecializationOf;
-  @hasMany('governing-body', { inverse: 'isTimeSpecializationOf' })
+  @hasMany('governing-body', { inverse: 'isTimeSpecializationOf', async: true })
   hasTimeSpecializations;
 
   rdfaBindings = {

--- a/app/models/mapping.js
+++ b/app/models/mapping.js
@@ -5,5 +5,6 @@ export default class MappingModel extends Model {
   @attr('string') type;
   @attr uri;
   @belongsTo('code-list', { inverse: 'mappings', async: true }) codeList;
-  @belongsTo('shape', { polyMorphic: true, async: true }) expects;
+  @belongsTo('shape', { inverse: null, polyMorphic: true, async: true })
+  expects;
 }

--- a/app/models/mapping.js
+++ b/app/models/mapping.js
@@ -4,6 +4,6 @@ export default class MappingModel extends Model {
   @attr('string') variable;
   @attr('string') type;
   @attr uri;
-  @belongsTo('code-list', { inverse: 'mappings' }) codeList;
-  @belongsTo('shape', { polyMorphic: true }) expects;
+  @belongsTo('code-list', { inverse: 'mappings', async: true }) codeList;
+  @belongsTo('shape', { polyMorphic: true, async: true }) expects;
 }

--- a/app/models/published-regulatory-attachment-container.js
+++ b/app/models/published-regulatory-attachment-container.js
@@ -1,6 +1,8 @@
 import Model, { belongsTo } from '@ember-data/model';
 
 export default class PublishedRegulatoryAttachmentContainer extends Model {
-  @belongsTo('published-regulatory-attachment', { async: true }) currentVersion;
-  @belongsTo('document-container', { async: true }) derivedFrom;
+  @belongsTo('published-regulatory-attachment', { inverse: null, async: true })
+  currentVersion;
+  @belongsTo('document-container', { inverse: 'publishedVersion', async: true })
+  derivedFrom;
 }

--- a/app/models/published-regulatory-attachment-container.js
+++ b/app/models/published-regulatory-attachment-container.js
@@ -1,6 +1,6 @@
 import Model, { belongsTo } from '@ember-data/model';
 
 export default class PublishedRegulatoryAttachmentContainer extends Model {
-  @belongsTo('published-regulatory-attachment') currentVersion;
-  @belongsTo('document-container') derivedFrom;
+  @belongsTo('published-regulatory-attachment', { async: true }) currentVersion;
+  @belongsTo('document-container', { async: true }) derivedFrom;
 }

--- a/app/models/published-regulatory-attachment.js
+++ b/app/models/published-regulatory-attachment.js
@@ -1,7 +1,8 @@
 import Model, { attr, belongsTo } from '@ember-data/model';
 
 export default class PublishedRegulatoryAttachment extends Model {
-  @belongsTo('editor-document', { async: true }) derivedFrom;
+  @belongsTo('editor-document', { async: true, inverse: 'publishedVersion' })
+  derivedFrom;
   @attr validThrough;
   @attr name;
   @attr format;

--- a/app/models/published-regulatory-attachment.js
+++ b/app/models/published-regulatory-attachment.js
@@ -1,7 +1,7 @@
 import Model, { attr, belongsTo } from '@ember-data/model';
 
 export default class PublishedRegulatoryAttachment extends Model {
-  @belongsTo('editor-document') derivedFrom;
+  @belongsTo('editor-document', { async: true }) derivedFrom;
   @attr validThrough;
   @attr name;
   @attr format;

--- a/app/models/regulatory-attachment-publication-task.js
+++ b/app/models/regulatory-attachment-publication-task.js
@@ -1,6 +1,7 @@
 import Model, { attr, belongsTo } from '@ember-data/model';
 
 export default class RegulatoryAttachmentPublicationTask extends Model {
-  @belongsTo('document-container', { async: true }) documentContainer;
+  @belongsTo('document-container', { async: true, inverse: null })
+  documentContainer;
   @attr status;
 }

--- a/app/models/regulatory-attachment-publication-task.js
+++ b/app/models/regulatory-attachment-publication-task.js
@@ -1,6 +1,6 @@
 import Model, { attr, belongsTo } from '@ember-data/model';
 
 export default class RegulatoryAttachmentPublicationTask extends Model {
-  @belongsTo('document-container') documentContainer;
+  @belongsTo('document-container', { async: true }) documentContainer;
   @attr status;
 }

--- a/app/models/shape.js
+++ b/app/models/shape.js
@@ -1,7 +1,7 @@
 import Model, { belongsTo } from '@ember-data/model';
 
 export default class ShapeModel extends Model {
-  @belongsTo('resource', { polyMorphic: true }) targetClass;
-  @belongsTo('resource', { polyMorphic: true }) targetNode;
-  @belongsTo('concept') targetHasConcept;
+  @belongsTo('resource', { polyMorphic: true, async: true }) targetClass;
+  @belongsTo('resource', { polyMorphic: true, async: true }) targetNode;
+  @belongsTo('concept', { async: true }) targetHasConcept;
 }

--- a/app/models/shape.js
+++ b/app/models/shape.js
@@ -1,7 +1,9 @@
 import Model, { belongsTo } from '@ember-data/model';
 
 export default class ShapeModel extends Model {
-  @belongsTo('resource', { polyMorphic: true, async: true }) targetClass;
-  @belongsTo('resource', { polyMorphic: true, async: true }) targetNode;
-  @belongsTo('concept', { async: true }) targetHasConcept;
+  @belongsTo('resource', { polyMorphic: true, async: true, inverse: null })
+  targetClass;
+  @belongsTo('resource', { polyMorphic: true, async: true, inverse: null })
+  targetNode;
+  @belongsTo('concept', { async: true, inverse: null }) targetHasConcept;
 }

--- a/app/models/skos-concept.js
+++ b/app/models/skos-concept.js
@@ -5,6 +5,10 @@ export default class SkosConcept extends Model {
   @attr label;
   @attr('datetime') createdOn;
   @attr position;
-  @belongsTo('concept-scheme', { inverse: 'concepts', polymorphic: true })
+  @belongsTo('concept-scheme', {
+    inverse: 'concepts',
+    polymorphic: true,
+    async: true,
+  })
   inScheme;
 }

--- a/app/models/user.js
+++ b/app/models/user.js
@@ -5,10 +5,10 @@ export default class UserModel extends Model {
   @attr familyName;
   @attr rijksregisterNummer;
 
-  @hasMany('account', { inverse: null })
+  @hasMany('account', { inverse: null, async: true })
   account;
 
-  @hasMany('administrative-units', { inverse: null })
+  @hasMany('administrative-units', { inverse: null, async: true })
   groups;
 
   get fullName() {

--- a/app/modifiers/yasgui.js
+++ b/app/modifiers/yasgui.js
@@ -1,26 +1,29 @@
 import { modifier } from 'ember-modifier';
 import Yasgui from '@triply/yasgui';
 
-export default modifier(function yasgui(element /*, params, hash*/) {
-  const config = {
-    /**
-     * Change the default request configuration, such as the headers
-     * and default yasgui endpoint.
-     * Define these fields as plain values, or as a getter function
-     */
-    requestConfig: {
-      endpoint: '/sparql',
-      method: 'POST',
-    },
-    // Allow resizing of the Yasqe editor
-    resizeable: false,
+export default modifier(
+  function yasgui(element /*, params, hash*/) {
+    const config = {
+      /**
+       * Change the default request configuration, such as the headers
+       * and default yasgui endpoint.
+       * Define these fields as plain values, or as a getter function
+       */
+      requestConfig: {
+        endpoint: '/sparql',
+        method: 'POST',
+      },
+      // Allow resizing of the Yasqe editor
+      resizeable: false,
 
-    // Whether to autofocus on Yasqe on page load
-    autofocus: true,
+      // Whether to autofocus on Yasqe on page load
+      autofocus: true,
 
-    // Use the default endpoint when a new tab is opened
-    copyEndpointOnNewTab: true,
-  };
+      // Use the default endpoint when a new tab is opened
+      copyEndpointOnNewTab: true,
+    };
 
-  new Yasgui(element, config);
-});
+    new Yasgui(element, config);
+  },
+  { eager: false }
+);

--- a/app/templates/mock-login.hbs
+++ b/app/templates/mock-login.hbs
@@ -14,20 +14,22 @@
               <div
                 class="au-o-box au-o-box--small au-c-card au-u-margin-bottom-small"
               >
-                <AuButton
-                  @skin="tertiary"
-                  {{on
-                    "click"
-                    (fn login.login account.id account.user.groups.firstObject.id)
-                  }}
-                >
-                  <strong>
-                    {{account.user.firstName}}
-                    {{account.user.familyName}}
-                    -&nbsp;
-                  </strong>
-                  {{account.user.groups.firstObject.name}}
-                </AuButton>
+                {{#let (await (this.getGroup account)) as |group|}}
+                  <AuButton
+                    @skin="tertiary"
+                    {{on
+                      "click"
+                      (fn login.login account.id group.id)
+                    }}
+                  >
+                    <strong>
+                      {{account.user.firstName}}
+                      {{account.user.familyName}}
+                      -&nbsp;
+                    </strong>
+                    {{group.name}}
+                  </AuButton>
+                {{/let}}
               </div>
             </li>
           {{/each}}

--- a/package-lock.json
+++ b/package-lock.json
@@ -52,6 +52,7 @@
         "ember-mu-transform-helpers": "^2.1.2",
         "ember-page-title": "^7.0.0",
         "ember-power-select": "^5.0.4",
+        "ember-promise-helpers": "^2.0.0",
         "ember-qunit": "^6.0.0",
         "ember-resolver": "^8.0.3",
         "ember-source": "~4.8.0",
@@ -18711,6 +18712,240 @@
       }
     },
     "node_modules/ember-power-select/node_modules/walk-sync": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/walk-sync/-/walk-sync-2.2.0.tgz",
+      "integrity": "sha512-IC8sL7aB4/ZgFcGI2T1LczZeFWZ06b3zoHH7jBPyHxOtIIz1jppWHjjEXkOFvFojBVAK9pV7g47xOZ4LW3QLfg==",
+      "dev": true,
+      "dependencies": {
+        "@types/minimatch": "^3.0.3",
+        "ensure-posix-path": "^1.1.0",
+        "matcher-collection": "^2.0.0",
+        "minimatch": "^3.0.4"
+      },
+      "engines": {
+        "node": "8.* || >= 10.*"
+      }
+    },
+    "node_modules/ember-promise-helpers": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ember-promise-helpers/-/ember-promise-helpers-2.0.0.tgz",
+      "integrity": "sha512-ZQlzSRjCdDgGBlXHtk+LKmxOlXWKalBBZrmYlr2X/kqNf7vaVUnlKQD1T+sRzwnsZZTQwL5PKfLmSWF3hFD69g==",
+      "dev": true,
+      "dependencies": {
+        "ember-cli-babel": "^7.26.6",
+        "ember-cli-htmlbars": "^5.7.1"
+      },
+      "engines": {
+        "node": "12.* || 14.* || >= 16"
+      }
+    },
+    "node_modules/ember-promise-helpers/node_modules/async-disk-cache": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/async-disk-cache/-/async-disk-cache-2.1.0.tgz",
+      "integrity": "sha512-iH+boep2xivfD9wMaZWkywYIURSmsL96d6MoqrC94BnGSvXE4Quf8hnJiHGFYhw/nLeIa1XyRaf4vvcvkwAefg==",
+      "dev": true,
+      "dependencies": {
+        "debug": "^4.1.1",
+        "heimdalljs": "^0.2.3",
+        "istextorbinary": "^2.5.1",
+        "mkdirp": "^0.5.0",
+        "rimraf": "^3.0.0",
+        "rsvp": "^4.8.5",
+        "username-sync": "^1.0.2"
+      },
+      "engines": {
+        "node": "8.* || >= 10.*"
+      }
+    },
+    "node_modules/ember-promise-helpers/node_modules/broccoli-persistent-filter": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/broccoli-persistent-filter/-/broccoli-persistent-filter-3.1.3.tgz",
+      "integrity": "sha512-Q+8iezprZzL9voaBsDY3rQVl7c7H5h+bvv8SpzCZXPZgfBFCbx7KFQ2c3rZR6lW5k4Kwoqt7jG+rZMUg67Gwxw==",
+      "dev": true,
+      "dependencies": {
+        "async-disk-cache": "^2.0.0",
+        "async-promise-queue": "^1.0.3",
+        "broccoli-plugin": "^4.0.3",
+        "fs-tree-diff": "^2.0.0",
+        "hash-for-dep": "^1.5.0",
+        "heimdalljs": "^0.2.1",
+        "heimdalljs-logger": "^0.1.7",
+        "promise-map-series": "^0.2.1",
+        "rimraf": "^3.0.0",
+        "symlink-or-copy": "^1.0.1",
+        "sync-disk-cache": "^2.0.0"
+      },
+      "engines": {
+        "node": "10.* || >= 12.*"
+      }
+    },
+    "node_modules/ember-promise-helpers/node_modules/broccoli-plugin": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/broccoli-plugin/-/broccoli-plugin-4.0.7.tgz",
+      "integrity": "sha512-a4zUsWtA1uns1K7p9rExYVYG99rdKeGRymW0qOCNkvDPHQxVi3yVyJHhQbM3EZwdt2E0mnhr5e0c/bPpJ7p3Wg==",
+      "dev": true,
+      "dependencies": {
+        "broccoli-node-api": "^1.7.0",
+        "broccoli-output-wrapper": "^3.2.5",
+        "fs-merger": "^3.2.1",
+        "promise-map-series": "^0.3.0",
+        "quick-temp": "^0.1.8",
+        "rimraf": "^3.0.2",
+        "symlink-or-copy": "^1.3.1"
+      },
+      "engines": {
+        "node": "10.* || >= 12.*"
+      }
+    },
+    "node_modules/ember-promise-helpers/node_modules/broccoli-plugin/node_modules/promise-map-series": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/promise-map-series/-/promise-map-series-0.3.0.tgz",
+      "integrity": "sha512-3npG2NGhTc8BWBolLLf8l/92OxMGaRLbqvIh9wjCHhDXNvk4zsxaTaCpiCunW09qWPrN2zeNSNwRLVBrQQtutA==",
+      "dev": true,
+      "engines": {
+        "node": "10.* || >= 12.*"
+      }
+    },
+    "node_modules/ember-promise-helpers/node_modules/editions": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/editions/-/editions-2.3.1.tgz",
+      "integrity": "sha512-ptGvkwTvGdGfC0hfhKg0MT+TRLRKGtUiWGBInxOm5pz7ssADezahjCUaYuZ8Dr+C05FW0AECIIPt4WBxVINEhA==",
+      "dev": true,
+      "dependencies": {
+        "errlop": "^2.0.0",
+        "semver": "^6.3.0"
+      },
+      "engines": {
+        "node": ">=0.8"
+      },
+      "funding": {
+        "url": "https://bevry.me/fund"
+      }
+    },
+    "node_modules/ember-promise-helpers/node_modules/editions/node_modules/semver": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/ember-promise-helpers/node_modules/ember-cli-htmlbars": {
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/ember-cli-htmlbars/-/ember-cli-htmlbars-5.7.2.tgz",
+      "integrity": "sha512-Uj6R+3TtBV5RZoJY14oZn/sNPnc+UgmC8nb5rI4P3fR/gYoyTFIZSXiIM7zl++IpMoIrocxOrgt+mhonKphgGg==",
+      "dev": true,
+      "dependencies": {
+        "@ember/edition-utils": "^1.2.0",
+        "babel-plugin-htmlbars-inline-precompile": "^5.0.0",
+        "broccoli-debug": "^0.6.5",
+        "broccoli-persistent-filter": "^3.1.2",
+        "broccoli-plugin": "^4.0.3",
+        "common-tags": "^1.8.0",
+        "ember-cli-babel-plugin-helpers": "^1.1.1",
+        "ember-cli-version-checker": "^5.1.2",
+        "fs-tree-diff": "^2.0.1",
+        "hash-for-dep": "^1.5.1",
+        "heimdalljs-logger": "^0.1.10",
+        "json-stable-stringify": "^1.0.1",
+        "semver": "^7.3.4",
+        "silent-error": "^1.1.1",
+        "strip-bom": "^4.0.0",
+        "walk-sync": "^2.2.0"
+      },
+      "engines": {
+        "node": "10.* || >= 12.*"
+      }
+    },
+    "node_modules/ember-promise-helpers/node_modules/fs-tree-diff": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/fs-tree-diff/-/fs-tree-diff-2.0.1.tgz",
+      "integrity": "sha512-x+CfAZ/lJHQqwlD64pYM5QxWjzWhSjroaVsr8PW831zOApL55qPibed0c+xebaLWVr2BnHFoHdrwOv8pzt8R5A==",
+      "dev": true,
+      "dependencies": {
+        "@types/symlink-or-copy": "^1.2.0",
+        "heimdalljs-logger": "^0.1.7",
+        "object-assign": "^4.1.0",
+        "path-posix": "^1.0.0",
+        "symlink-or-copy": "^1.1.8"
+      },
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/ember-promise-helpers/node_modules/istextorbinary": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/istextorbinary/-/istextorbinary-2.6.0.tgz",
+      "integrity": "sha512-+XRlFseT8B3L9KyjxxLjfXSLMuErKDsd8DBNrsaxoViABMEZlOSCstwmw0qpoFX3+U6yWU1yhLudAe6/lETGGA==",
+      "dev": true,
+      "dependencies": {
+        "binaryextensions": "^2.1.2",
+        "editions": "^2.2.0",
+        "textextensions": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://bevry.me/fund"
+      }
+    },
+    "node_modules/ember-promise-helpers/node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "dev": true,
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/ember-promise-helpers/node_modules/mkdirp": {
+      "version": "0.5.6",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
+      "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
+      "dev": true,
+      "dependencies": {
+        "minimist": "^1.2.6"
+      },
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      }
+    },
+    "node_modules/ember-promise-helpers/node_modules/rimraf": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+      "dev": true,
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/ember-promise-helpers/node_modules/rsvp": {
+      "version": "4.8.5",
+      "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-4.8.5.tgz",
+      "integrity": "sha512-nfMOlASu9OnRJo1mbEk2cz0D56a1MBNrJ7orjRZQG10XDyuvwksKbuXNp6qa+kbn839HwjwhBzhFmdsaEAfauA==",
+      "dev": true,
+      "engines": {
+        "node": "6.* || >= 7.*"
+      }
+    },
+    "node_modules/ember-promise-helpers/node_modules/strip-bom": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-4.0.0.tgz",
+      "integrity": "sha512-3xurFv5tEgii33Zi8Jtp55wEIILR9eh34FAW00PZf+JnSsTmV/ioewSgQl97JHvgjoRGwPShsWm+IdrxB35d0w==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ember-promise-helpers/node_modules/walk-sync": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/walk-sync/-/walk-sync-2.2.0.tgz",
       "integrity": "sha512-IC8sL7aB4/ZgFcGI2T1LczZeFWZ06b3zoHH7jBPyHxOtIIz1jppWHjjEXkOFvFojBVAK9pV7g47xOZ4LW3QLfg==",

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "ember-mu-transform-helpers": "^2.1.2",
     "ember-page-title": "^7.0.0",
     "ember-power-select": "^5.0.4",
+    "ember-promise-helpers": "^2.0.0",
     "ember-qunit": "^6.0.0",
     "ember-resolver": "^8.0.3",
     "ember-source": "~4.8.0",


### PR DESCRIPTION
This PR is a start to removing/replacing deprecated code. Specifically, it replaces the following methods:
- `toArray` is replaced by `slice`
- `firstObject` is replaced by index accessing

Additionally this PR adds the following things:
- Explicit `async: true` attributes to ember-data relationships
- Explicit `inverse` attributes to ember-data relationships if missing
- An explicit application adapter