### PR TITLE
Update ember-power-select to 7.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -51,7 +51,7 @@
         "ember-load-initializers": "^2.1.2",
         "ember-mu-transform-helpers": "^2.1.2",
         "ember-page-title": "^7.0.0",
-        "ember-power-select": "^5.0.4",
+        "ember-power-select": "^7.0.0",
         "ember-qunit": "^6.0.0",
         "ember-resolver": "^8.0.3",
         "ember-source": "~4.8.0",
@@ -133,6 +133,168 @@
       },
       "peerDependencies": {
         "ember-source": "^3.28.0 || ^4.0.0"
+      }
+    },
+    "node_modules/@appuniversum/ember-appuniversum/node_modules/ember-basic-dropdown": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/ember-basic-dropdown/-/ember-basic-dropdown-6.0.2.tgz",
+      "integrity": "sha512-JgI/cy7eS/Y2WoQl7B2Mko/1aFTAlxr5d+KpQeH7rBKOFml7IQtLvhiDQrpU/FLkrQ9aLNEJtzwtDZV1xQxAKA==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "@ember/render-modifiers": "^2.0.4",
+        "@embroider/macros": "^1.2.0",
+        "@embroider/util": "^1.2.0",
+        "@glimmer/component": "^1.0.4",
+        "@glimmer/tracking": "^1.0.4",
+        "ember-cli-babel": "^7.26.11",
+        "ember-cli-htmlbars": "^6.0.1",
+        "ember-cli-typescript": "^4.2.1",
+        "ember-element-helper": "^0.6.0",
+        "ember-get-config": "^2.1.1",
+        "ember-maybe-in-element": "^2.0.3",
+        "ember-modifier": "^3.2.7",
+        "ember-style-modifier": "^0.8.0 || ^1.0.0",
+        "ember-truth-helpers": "^2.1.0 || ^3.0.0"
+      },
+      "engines": {
+        "node": "12.* || 14.* || >= 16"
+      }
+    },
+    "node_modules/@appuniversum/ember-appuniversum/node_modules/ember-cli-typescript": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/ember-cli-typescript/-/ember-cli-typescript-4.2.1.tgz",
+      "integrity": "sha512-0iKTZ+/wH6UB/VTWKvGuXlmwiE8HSIGcxHamwNhEC5x1mN3z8RfvsFZdQWYUzIWFN2Tek0gmepGRPTwWdBYl/A==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "ansi-to-html": "^0.6.15",
+        "broccoli-stew": "^3.0.0",
+        "debug": "^4.0.0",
+        "execa": "^4.0.0",
+        "fs-extra": "^9.0.1",
+        "resolve": "^1.5.0",
+        "rsvp": "^4.8.1",
+        "semver": "^7.3.2",
+        "stagehand": "^1.0.0",
+        "walk-sync": "^2.2.0"
+      },
+      "engines": {
+        "node": "10.* || >= 12.*"
+      }
+    },
+    "node_modules/@appuniversum/ember-appuniversum/node_modules/ember-power-select": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/ember-power-select/-/ember-power-select-6.0.1.tgz",
+      "integrity": "sha512-YslsjEUzdHhFfUP7IlklQuKt6rFG/VS38JLCjTYiCcBKrl76pxky/PoGMx3V+Ukh5mI77mGfA7BSKpKv8MAQAw==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "@embroider/util": "^1.0.0",
+        "@glimmer/component": "^1.1.2",
+        "@glimmer/tracking": "^1.1.2",
+        "ember-assign-helper": "^0.4.0",
+        "ember-basic-dropdown": "^6.0.0",
+        "ember-cli-babel": "^7.26.11",
+        "ember-cli-htmlbars": "^6.1.0",
+        "ember-cli-typescript": "^4.2.0",
+        "ember-concurrency": ">=1.0.0 <3",
+        "ember-concurrency-decorators": "^2.0.0",
+        "ember-text-measurer": "^0.6.0",
+        "ember-truth-helpers": "^3.0.0"
+      },
+      "engines": {
+        "node": "14.* || >= 16"
+      }
+    },
+    "node_modules/@appuniversum/ember-appuniversum/node_modules/ember-style-modifier": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/ember-style-modifier/-/ember-style-modifier-1.0.0.tgz",
+      "integrity": "sha512-ANkYpOeI3/tkRxVz750ymb8cQBqfBTKOUOz4RPRsNys8rlaBiaKEa95XLz1JWfCXCzjmqe8i2cIdnAMix+nb3A==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "ember-cli-babel": "^7.26.11",
+        "ember-modifier": "^3.2.7"
+      },
+      "engines": {
+        "node": "14.* || >= 16"
+      }
+    },
+    "node_modules/@appuniversum/ember-appuniversum/node_modules/execa": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-4.1.0.tgz",
+      "integrity": "sha512-j5W0//W7f8UxAn8hXVnwG8tLwdiUy4FJLcSupCg6maBYZDpyBvTApK7KyuI4bKj8KOh1r2YH+6ucuYtJv1bTZA==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "cross-spawn": "^7.0.0",
+        "get-stream": "^5.0.0",
+        "human-signals": "^1.1.1",
+        "is-stream": "^2.0.0",
+        "merge-stream": "^2.0.0",
+        "npm-run-path": "^4.0.0",
+        "onetime": "^5.1.0",
+        "signal-exit": "^3.0.2",
+        "strip-final-newline": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
+    "node_modules/@appuniversum/ember-appuniversum/node_modules/get-stream": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+      "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "pump": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@appuniversum/ember-appuniversum/node_modules/human-signals": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-1.1.1.tgz",
+      "integrity": "sha512-SEQu7vl8KjNL2eoGBLF3+wAjpsNfA9XMlXAYj/3EdaNfAlxKthD1xjEQfGOUhllCGGJVNY34bRr6lPINhNjyZw==",
+      "dev": true,
+      "optional": true,
+      "engines": {
+        "node": ">=8.12.0"
+      }
+    },
+    "node_modules/@appuniversum/ember-appuniversum/node_modules/rsvp": {
+      "version": "4.8.5",
+      "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-4.8.5.tgz",
+      "integrity": "sha512-nfMOlASu9OnRJo1mbEk2cz0D56a1MBNrJ7orjRZQG10XDyuvwksKbuXNp6qa+kbn839HwjwhBzhFmdsaEAfauA==",
+      "dev": true,
+      "optional": true,
+      "engines": {
+        "node": "6.* || >= 7.*"
+      }
+    },
+    "node_modules/@appuniversum/ember-appuniversum/node_modules/walk-sync": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/walk-sync/-/walk-sync-2.2.0.tgz",
+      "integrity": "sha512-IC8sL7aB4/ZgFcGI2T1LczZeFWZ06b3zoHH7jBPyHxOtIIz1jppWHjjEXkOFvFojBVAK9pV7g47xOZ4LW3QLfg==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "@types/minimatch": "^3.0.3",
+        "ensure-posix-path": "^1.1.0",
+        "matcher-collection": "^2.0.0",
+        "minimatch": "^3.0.4"
+      },
+      "engines": {
+        "node": "8.* || >= 10.*"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -6441,9 +6603,9 @@
       }
     },
     "node_modules/babel-plugin-ember-template-compilation": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-ember-template-compilation/-/babel-plugin-ember-template-compilation-2.0.0.tgz",
-      "integrity": "sha512-d+4jaB2ik0rt9TH0K9kOlKJeRBHEb373FgFMcU9ZaJL2zYuVXe19bqy+cWlLpLf1tpOBcBG9QTlFBCoImlOt1g==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/babel-plugin-ember-template-compilation/-/babel-plugin-ember-template-compilation-2.0.3.tgz",
+      "integrity": "sha512-SIetZD/uCLnzIBTJtzYGc2Q55TPqM5WyjuOgW+Is1W3SZVljlY3JD5Add29hDMs//OvXBWoXfOopQxkfG4/pIA==",
       "dev": true,
       "dependencies": {
         "babel-import-util": "^1.3.0"
@@ -11552,9 +11714,9 @@
       }
     },
     "node_modules/ember-auto-import": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/ember-auto-import/-/ember-auto-import-2.6.1.tgz",
-      "integrity": "sha512-3bCRi/pXp4QslmuCXGlSz9xwR7DF5oDx3zZO5OXKzNZihtkqAM1xvGuRIdQSl46pvbAXOkp8Odl5fOen1i0dRw==",
+      "version": "2.6.3",
+      "resolved": "https://registry.npmjs.org/ember-auto-import/-/ember-auto-import-2.6.3.tgz",
+      "integrity": "sha512-uLhrRDJYWCRvQ4JQ1e64XlSrqAKSd6PXaJ9ZsZI6Tlms9T4DtQFxNXasqji2ZRJBVrxEoLCRYX3RTldsQ0vNGQ==",
       "dev": true,
       "dependencies": {
         "@babel/core": "^7.16.7",
@@ -11565,6 +11727,7 @@
         "@embroider/shared-internals": "^2.0.0",
         "babel-loader": "^8.0.6",
         "babel-plugin-ember-modules-api-polyfill": "^3.5.0",
+        "babel-plugin-ember-template-compilation": "^2.0.1",
         "babel-plugin-htmlbars-inline-precompile": "^5.2.1",
         "babel-plugin-syntax-dynamic-import": "^6.18.0",
         "broccoli-debug": "^0.6.4",
@@ -11693,33 +11856,35 @@
       }
     },
     "node_modules/ember-basic-dropdown": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/ember-basic-dropdown/-/ember-basic-dropdown-4.0.5.tgz",
-      "integrity": "sha512-cD0cnL4gjoNNGJ+kMNtGlsikan5v5aVWp5Mkv8fgnLS96EGhmAMlTiRBexmyzK+4Zbe+xOlZKNQva4bZ7FrQGQ==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/ember-basic-dropdown/-/ember-basic-dropdown-7.1.0.tgz",
+      "integrity": "sha512-ZXFsX81WdF8WXjJb3VQjbZHqql+ozyQxh2YH44FODRd4K6xSLJt5Cvnl1CFcXawF/2+bI4u3b6Z3fIaJnGakGg==",
       "dev": true,
       "dependencies": {
-        "@ember/render-modifiers": "^2.0.4",
-        "@embroider/macros": "^1.2.0",
-        "@embroider/util": "^1.2.0",
-        "@glimmer/component": "^1.0.4",
-        "@glimmer/tracking": "^1.0.4",
+        "@ember/render-modifiers": "^2.0.5",
+        "@embroider/macros": "^1.10.0",
+        "@embroider/util": "^1.10.0",
+        "@glimmer/component": "^1.1.2",
+        "@glimmer/tracking": "^1.1.2",
+        "ember-auto-import": "^2.6.3",
         "ember-cli-babel": "^7.26.11",
-        "ember-cli-htmlbars": "^6.0.1",
-        "ember-cli-typescript": "^4.2.1",
-        "ember-element-helper": "^0.6.0",
-        "ember-get-config": "^1.0.2",
-        "ember-maybe-in-element": "^2.0.3",
-        "ember-style-modifier": "^0.7.0",
+        "ember-cli-htmlbars": "^6.2.0",
+        "ember-cli-typescript": "^5.2.1",
+        "ember-element-helper": "^0.6.1",
+        "ember-get-config": "^2.1.1",
+        "ember-maybe-in-element": "^2.1.0",
+        "ember-modifier": "^3.2.7 || ^4.0.0",
+        "ember-style-modifier": "^0.8.0 || ^1.0.0 || ^2.0.0 || ^3.0.0",
         "ember-truth-helpers": "^2.1.0 || ^3.0.0"
       },
       "engines": {
-        "node": "12.* || 14.* || >= 16"
+        "node": "16.* || >= 18"
       }
     },
     "node_modules/ember-basic-dropdown/node_modules/ember-cli-typescript": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/ember-cli-typescript/-/ember-cli-typescript-4.2.1.tgz",
-      "integrity": "sha512-0iKTZ+/wH6UB/VTWKvGuXlmwiE8HSIGcxHamwNhEC5x1mN3z8RfvsFZdQWYUzIWFN2Tek0gmepGRPTwWdBYl/A==",
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/ember-cli-typescript/-/ember-cli-typescript-5.2.1.tgz",
+      "integrity": "sha512-qqp5TAIuPHxHiGXJKL+78Euyhy0zSKQMovPh8sJpN/ZBYx0H90pONufHR3anaMcp1snVfx4B+mb9+7ijOik8ZA==",
       "dev": true,
       "dependencies": {
         "ansi-to-html": "^0.6.15",
@@ -11734,20 +11899,7 @@
         "walk-sync": "^2.2.0"
       },
       "engines": {
-        "node": "10.* || >= 12.*"
-      }
-    },
-    "node_modules/ember-basic-dropdown/node_modules/ember-get-config": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/ember-get-config/-/ember-get-config-1.1.0.tgz",
-      "integrity": "sha512-diD+HwwY8QqpEk5DnDYfH7onYwl6NOgr1qv1ENbXih+/iiWYUVS/e0S/PlM7A4gdorD9spn1bnisnTLTf49Wpw==",
-      "dev": true,
-      "dependencies": {
-        "@embroider/macros": "^0.50.0 || ^1.0.0",
-        "ember-cli-babel": "^7.26.6"
-      },
-      "engines": {
-        "node": "12.* || 14.* || >= 16"
+        "node": ">= 12.*"
       }
     },
     "node_modules/ember-basic-dropdown/node_modules/execa": {
@@ -18611,32 +18763,31 @@
       }
     },
     "node_modules/ember-power-select": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/ember-power-select/-/ember-power-select-5.0.4.tgz",
-      "integrity": "sha512-FLVShZr3cYdLzymP+/0rXkfH5tD/FD958kynY86MWvn7ZyL2tXowlgVKY08n+PJHdo/vCrzqubRYckvXRSH6Bg==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/ember-power-select/-/ember-power-select-7.0.0.tgz",
+      "integrity": "sha512-FKeeF1PqYw5XfPPGoHP0aPG0X/3W15v9O2nk0z54oVeLIUTn2R3Ry9iSLa0/mAjDi1Cn7Zdnyki4Z1oM2aWOuA==",
       "dev": true,
       "dependencies": {
         "@embroider/util": "^1.0.0",
-        "@glimmer/component": "^1.0.4",
-        "@glimmer/tracking": "^1.0.4",
+        "@glimmer/component": "^1.1.2",
+        "@glimmer/tracking": "^1.1.2",
         "ember-assign-helper": "^0.4.0",
-        "ember-basic-dropdown": "^3.1.0 || ^4.0.2",
-        "ember-cli-babel": "^7.26.0",
-        "ember-cli-htmlbars": "^6.0.0",
-        "ember-cli-typescript": "^4.2.0",
-        "ember-concurrency": ">=1.0.0 <3",
-        "ember-concurrency-decorators": "^2.0.0",
+        "ember-basic-dropdown": "^7.0.1",
+        "ember-cli-babel": "^7.26.11",
+        "ember-cli-htmlbars": "^6.1.0",
+        "ember-cli-typescript": "^5.0.0",
+        "ember-concurrency": "^2.0.0",
         "ember-text-measurer": "^0.6.0",
-        "ember-truth-helpers": "^2.1.0 || ^3.0.0"
+        "ember-truth-helpers": "^3.1.0"
       },
       "engines": {
-        "node": ">= 12"
+        "node": "14.* || >= 16"
       }
     },
     "node_modules/ember-power-select/node_modules/ember-cli-typescript": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/ember-cli-typescript/-/ember-cli-typescript-4.2.1.tgz",
-      "integrity": "sha512-0iKTZ+/wH6UB/VTWKvGuXlmwiE8HSIGcxHamwNhEC5x1mN3z8RfvsFZdQWYUzIWFN2Tek0gmepGRPTwWdBYl/A==",
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/ember-cli-typescript/-/ember-cli-typescript-5.2.1.tgz",
+      "integrity": "sha512-qqp5TAIuPHxHiGXJKL+78Euyhy0zSKQMovPh8sJpN/ZBYx0H90pONufHR3anaMcp1snVfx4B+mb9+7ijOik8ZA==",
       "dev": true,
       "dependencies": {
         "ansi-to-html": "^0.6.15",
@@ -18651,7 +18802,7 @@
         "walk-sync": "^2.2.0"
       },
       "engines": {
-        "node": "10.* || >= 12.*"
+        "node": ">= 12.*"
       }
     },
     "node_modules/ember-power-select/node_modules/execa": {
@@ -19121,16 +19272,20 @@
       }
     },
     "node_modules/ember-style-modifier": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/ember-style-modifier/-/ember-style-modifier-0.7.0.tgz",
-      "integrity": "sha512-iDzffiwJcb9j6gu3g8CxzZOTvRZ0BmLMEFl+uyqjiaj72VVND9+HbLyQRw1/ewPAtinhSktxxTTdwU/JO+stLw==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ember-style-modifier/-/ember-style-modifier-3.0.1.tgz",
+      "integrity": "sha512-WHRVIiqY/dpwDtVWlnHW0P4Z+Jha8QEwfaQdIF2ckJL77ZKdjbV2j1XZymS0Nzj61EGx5BM+YEsGL16r3hLv2A==",
       "dev": true,
       "dependencies": {
-        "ember-cli-babel": "^7.26.6",
-        "ember-modifier": "^3.0.0"
+        "ember-auto-import": "^2.5.0",
+        "ember-cli-babel": "^7.26.11",
+        "ember-modifier": "^3.2.7 || ^4.0.0"
       },
       "engines": {
-        "node": "12.* || 14.* || >= 16"
+        "node": "14.* || 16.* || >= 18"
+      },
+      "peerDependencies": {
+        "@ember/string": "^3.0.1"
       }
     },
     "node_modules/ember-template-imports": {

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "ember-load-initializers": "^2.1.2",
     "ember-mu-transform-helpers": "^2.1.2",
     "ember-page-title": "^7.0.0",
-    "ember-power-select": "^5.0.4",
+    "ember-power-select": "^7.0.0",
     "ember-qunit": "^6.0.0",
     "ember-resolver": "^8.0.3",
     "ember-source": "~4.8.0",


### PR DESCRIPTION
This PR updates ember-power-select to version 7.0.0. This new version removes some deprecated code:
- `toArray` is replace by `slice`
- deprecated code related to the `ember-modifier` package is no longer used.