### PR TITLE
fixed currrentSession.group can be undefined

### DIFF
--- a/app/controllers/edit.js
+++ b/app/controllers/edit.js
@@ -157,7 +157,7 @@ export default class EditController extends Controller {
         allowCustomFormat: true,
       },
       variable: {
-        publisher: this.currentSession.group.uri,
+        publisher: this.currentSession.group?.uri,
         defaultEndpoint: ENV.insertVariablePlugin.endpoint,
         variableTypes: ['text', 'number', 'date', 'codelist'],
       },


### PR DESCRIPTION
To be honest I don't know why this is needed. But it fixes the issue
In GN it doesn't happen because the editor is not rendered on a top route, maybe we should reestructure the routes of this app.
Solves https://binnenland.atlassian.net/browse/GN-4332