### PR TITLE
Fix type translation on codelist overview page

### DIFF
--- a/app/templates/codelists-management/index.hbs
+++ b/app/templates/codelists-management/index.hbs
@@ -75,7 +75,7 @@
       </td>
       <td>
         {{#if codelist.type}}
-          {{t (concat "codelist.attr.types." codelist.type.label)}}
+          {{t (concat "codelist.attr.types." codelist.type.value)}}
         {{else}}
           {{t "codelist.attr.types.singleSelect"}}
         {{/if}}


### PR DESCRIPTION
This PR fixes a translation issue with the type attribute of a codelist on the codelist overview page.

Related Jira ticket: https://binnenland.atlassian.net/browse/GN-4377