### PR TITLE
Update `@lblod/ember-rdfa-editor` to 3.10

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
         "@lblod/ember-acmidm-login": "^2.0.0-beta.1",
         "@lblod/ember-environment-banner": "^0.2.0",
         "@lblod/ember-mock-login": "^0.7.0",
-        "@lblod/ember-rdfa-editor": "^3.8.0",
+        "@lblod/ember-rdfa-editor": "^3.10.0",
         "@lblod/ember-rdfa-editor-lblod-plugins": "^8.0.1",
         "@release-it-plugins/lerna-changelog": "github:release-it-plugins/lerna-changelog",
         "broccoli-asset-rev": "^3.0.0",
@@ -4099,9 +4099,9 @@
       }
     },
     "node_modules/@lblod/ember-rdfa-editor": {
-      "version": "3.8.0",
-      "resolved": "https://registry.npmjs.org/@lblod/ember-rdfa-editor/-/ember-rdfa-editor-3.8.0.tgz",
-      "integrity": "sha512-QFVr21zgimyGJ5E1s74iJFVCWKwJKgTr3bu5dibKcJG+LQY0rzsywL/zzj8NMovmR8W5ieMd+lvileLfpBQeNg==",
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/@lblod/ember-rdfa-editor/-/ember-rdfa-editor-3.10.0.tgz",
+      "integrity": "sha512-vIERr5LBJSq0XeVgxntp8ip1nbvDzcRphLLK5lR0CkU4J3UQ8gEU1o6PaOxd3nrYWMZloR1iOC632mSoe77Ezg==",
       "dev": true,
       "dependencies": {
         "@codemirror/lang-html": "^6.1.1",
@@ -4136,7 +4136,7 @@
         "ember-intl": "^5.7.2",
         "ember-truth-helpers": "^3.0.0",
         "ember-unique-id-helper-polyfill": "^1.2.2",
-        "ember-velcro": "^1.1.0",
+        "ember-velcro": "^2.1.0",
         "handlebars": "^4.7.7",
         "handlebars-loader": "^1.7.2",
         "iter-tools": "^7.4.0",
@@ -5016,6 +5016,21 @@
       },
       "engines": {
         "node": "8.* || >= 10.*"
+      }
+    },
+    "node_modules/@lblod/ember-rdfa-editor/node_modules/ember-velcro": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/ember-velcro/-/ember-velcro-2.1.0.tgz",
+      "integrity": "sha512-5m1JDAGmTT9J8SrVL1NrBj6qe1L0dgb3T1muWL2b36HO4sCHn8/njT/GMHXorcbYz7C/PawYuxKpbILNaGa50A==",
+      "dev": true,
+      "dependencies": {
+        "@embroider/addon-shim": "^1.0.0",
+        "@floating-ui/dom": "^1.0.1",
+        "ember-functions-as-helper-polyfill": "^2.1.1",
+        "ember-modifier": "^3.2.7"
+      },
+      "engines": {
+        "node": "14.* || >= 16"
       }
     },
     "node_modules/@lblod/ember-rdfa-editor/node_modules/execa": {

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "@lblod/ember-acmidm-login": "^2.0.0-beta.1",
     "@lblod/ember-environment-banner": "^0.2.0",
     "@lblod/ember-mock-login": "^0.7.0",
-    "@lblod/ember-rdfa-editor": "^3.8.0",
+    "@lblod/ember-rdfa-editor": "^3.10.0",
     "@lblod/ember-rdfa-editor-lblod-plugins": "^8.0.1",
     "@release-it-plugins/lerna-changelog": "github:release-it-plugins/lerna-changelog",
     "broccoli-asset-rev": "^3.0.0",


### PR DESCRIPTION
## Overview
This PR updates `@lblod/ember-rdfa-editor` to version 3.10
<!-- high level overview of changes (not just "implement ticket") + *why* + design document, special notes like ticket partially implemented etc. -->

### Checks PR readiness
- [x] UI: works on smaller screen sizes
- [x] UI: feedback for any loading/error states
- [x] Check cancel/go-back flows
- [x] Check database state correct when deleting/updating (especially regarding relationships)
- [x] changelog
- [x] npm lint
- [x] no new deprecations