### PR TITLE
Update `@lblod/ember-rdfa-editor-lblod-plugins` to 8.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
         "@lblod/ember-environment-banner": "^0.2.0",
         "@lblod/ember-mock-login": "^0.7.0",
         "@lblod/ember-rdfa-editor": "^3.10.0",
-        "@lblod/ember-rdfa-editor-lblod-plugins": "^8.0.1",
+        "@lblod/ember-rdfa-editor-lblod-plugins": "^8.1.0",
         "@release-it-plugins/lerna-changelog": "github:release-it-plugins/lerna-changelog",
         "broccoli-asset-rev": "^3.0.0",
         "ember-auto-import": "^2.4.3",
@@ -4171,9 +4171,9 @@
       }
     },
     "node_modules/@lblod/ember-rdfa-editor-lblod-plugins": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/@lblod/ember-rdfa-editor-lblod-plugins/-/ember-rdfa-editor-lblod-plugins-8.0.1.tgz",
-      "integrity": "sha512-Yw61bKUyouAafQbbwgf8WL5Z3FHLDLz52Zl1EsEsJOwYrt8ShbyinjiIJoPKT8yVL69raIhi0fGnPoe60l6RmA==",
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/@lblod/ember-rdfa-editor-lblod-plugins/-/ember-rdfa-editor-lblod-plugins-8.1.0.tgz",
+      "integrity": "sha512-AP2jWD0Wug3skVCGaPmI79IlzlLwOSTsJ6QrRauJn6pENdnouqCgEmS9aeadXscndAV54fxBILcURO6LRiGxdw==",
       "dev": true,
       "dependencies": {
         "@codemirror/lang-html": "^6.4.3",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "@lblod/ember-environment-banner": "^0.2.0",
     "@lblod/ember-mock-login": "^0.7.0",
     "@lblod/ember-rdfa-editor": "^3.10.0",
-    "@lblod/ember-rdfa-editor-lblod-plugins": "^8.0.1",
+    "@lblod/ember-rdfa-editor-lblod-plugins": "^8.1.0",
     "@release-it-plugins/lerna-changelog": "github:release-it-plugins/lerna-changelog",
     "broccoli-asset-rev": "^3.0.0",
     "ember-auto-import": "^2.4.3",


### PR DESCRIPTION
## Overview
Updates `@lblod/ember-rdfa-editor-lblod-plugins` package to 8.1.0

### Checks PR readiness
- [x] UI: works on smaller screen sizes
- [x] UI: feedback for any loading/error states
- [x] Check cancel/go-back flows
- [x] Check database state correct when deleting/updating (especially regarding relationships)
- [x] changelog
- [x] npm lint
- [x] no new deprecations