### PR TITLE
GN-4379: Add code comment why editing codelist feature is not active

### DIFF
--- a/app/templates/edit.hbs
+++ b/app/templates/edit.hbs
@@ -112,6 +112,8 @@
             @controller={{this.editor}}
             @options={{this.config.date}}
           />
+          {{! VariablePlugin::TemplateVariableCard is not added on purpose
+          as an RB-document creator should not be able to set a "default" codelist option.}}
         </Sidebar>
       {{/if}}
     </:aside>


### PR DESCRIPTION
## Overview
A codelist is not editable (setting a default value) for RB-templates by design, as said in the jira issue's comments. This adds a code comment to the template to make this more explicit, as it is not expected (other variables like date, number etc can have a default value right now).

##### connected issues and PRs:
https://binnenland.atlassian.net/browse/GN-4379 => a comment is still open if this is the actual conclusion. 