### PR TITLE
Use AuModal for the modal shown when leaving a route

### DIFF
--- a/app/components/codelist-form.hbs
+++ b/app/components/codelist-form.hbs
@@ -196,3 +196,7 @@
     </table>
   </div>
 </div>
+
+<ConfirmRouteLeave
+  @enabled={{not this.allPristine}}
+/>

--- a/app/components/confirm-route-leave.hbs
+++ b/app/components/confirm-route-leave.hbs
@@ -1,0 +1,19 @@
+<AuModal
+  @title={{t 'utility.confirmation.body'}}
+  @modalOpen={{and this.showConfirmModal @enabled}}
+  @closeModal={{this.onCancel}} as |Modal|
+>
+  <Modal.Body>
+    <p>
+      {{or @message (t 'utility.confirm-leave-without-saving')}}
+    </p>
+  </Modal.Body>
+  <Modal.Footer>
+    <AuButton @alert={{true}} {{on 'click' this.onConfirm}}>
+      {{or @confirmMessage (t 'utility.discard-changes')}}
+    </AuButton>
+    <AuButton @skin='secondary' {{on 'click' this.onCancel}}>
+      {{t 'utility.cancel'}}
+    </AuButton>
+  </Modal.Footer>
+</AuModal>

--- a/app/components/confirm-route-leave.js
+++ b/app/components/confirm-route-leave.js
@@ -1,9 +1,23 @@
 import Component from '@glimmer/component';
 import { service } from '@ember/service';
 import isLoadingRoute from '../utils/is-loading-route';
+import { action } from '@ember/object';
+import { tracked } from '@glimmer/tracking';
 
+/**
+ * Show a modal during a route transition that stops the transition if cancel is pressed.
+ * By default it will show a message to confirm to discard unsaved changes.
+ * @message (optional) the message to show in the modal
+ * @confirmMessage (optional) the text to show in the confirm button
+ * @enabled Should the modal be shown on a transition
+ * @onConfirm (optional) hook when confirmation is clicked
+ * @onCancel (optional) hook when cancellation is clicked
+ */
 export default class ConfirmRouteLeaveComponent extends Component {
   @service router;
+  isConfirmedTransition = false;
+  @tracked showConfirmModal = false;
+  lastTransition = null;
 
   constructor(...args) {
     super(...args);
@@ -18,35 +32,55 @@ export default class ConfirmRouteLeaveComponent extends Component {
     this.router.off('routeWillChange', this, this.confirm);
   }
 
-  onConfirm(transition) {
+  @action
+  onConfirm() {
     if (this.args.onConfirm) {
-      this.args.onConfirm(transition);
+      this.args.onConfirm(this.lastTransition);
     }
+    this.isConfirmedTransition = true;
+    this.lastTransition.retry().then(() => {
+      this.reset();
+    });
   }
 
-  onCancel(transition) {
+  @action
+  onCancel() {
     if (this.args.onCancel) {
-      this.args.onCancel(transition);
-    } else {
-      transition.abort();
+      this.args.onCancel(this.lastTransition);
+    }
+    this.reset();
+  }
 
-      if (window.history) {
-        window.history.forward();
-      }
+  abortTransition(transition) {
+    transition.abort();
+    if (window.history) {
+      window.history.forward();
     }
   }
 
   confirm(transition) {
-    if (transition.isAborted || isLoadingRoute(transition.to)) {
+    if (
+      this.isConfirmedTransition ||
+      !this.args.enabled ||
+      transition.isAborted ||
+      isLoadingRoute(transition.to)
+    ) {
       return;
     }
-    if (this.args.enabled) {
-      if (window.confirm(this.args.message)) {
-        this.onConfirm(transition);
-      } else {
-        this.onCancel(transition);
-      }
+
+    this.abortTransition(transition);
+
+    if (this.showConfirmModal) {
+      return;
     }
+    this.lastTransition = transition;
+    this.showConfirmModal = true;
+  }
+
+  reset() {
+    this.showConfirmModal = false;
+    this.isConfirmedTransition = false;
+    this.lastTransition = null;
   }
 
   willDestroy(...args) {

--- a/app/templates/edit.hbs
+++ b/app/templates/edit.hbs
@@ -119,5 +119,4 @@
 {{/if}}
 <ConfirmRouteLeave
   @enabled={{this.dirty}}
-  @message={{t 'reglement-edit.confirm-leave-without-saving'}}
 />

--- a/app/templates/snippets-management/edit/edit-snippet.hbs
+++ b/app/templates/snippets-management/edit/edit-snippet.hbs
@@ -123,5 +123,4 @@
 {{/if}}
 <ConfirmRouteLeave
   @enabled={{this.dirty}}
-  @message={{t 'reglement-edit.confirm-leave-without-saving'}}
 />

--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -38,6 +38,9 @@ utility:
   save: Save
   saving: Saving...
   save-and-publish: Save and publish
+  confirm-leave-without-saving: Are you sure you would like to leave this page without saving your changes?
+  confirm: Confirm
+  discard-changes: Discard changes
   cancel: Cancel
   edit: Edit
   delete: Delete
@@ -99,7 +102,6 @@ reglement-edit:
   edit: Edit attachment
   return: Go Back
   saving: Saving
-  confirm-leave-without-saving: Are you sure you would like to leave this page without saving your changes?
   document-title-placeholder: Enter document title
   insert-title: Insert document title
 auth:

--- a/translations/nl-BE.yaml
+++ b/translations/nl-BE.yaml
@@ -38,6 +38,9 @@ utility:
   save: Opslaan
   save-and-publish: Bewaar en maak beschikbaar
   saving: Bezig met opslaan
+  confirm-leave-without-saving: Bent u zeker dat u deze pagina wilt verlaten zonder uw wijzigingen op te slaan?
+  confirm: Bevestigen
+  discard-changes: Wijzigingen verwerpen
   cancel: Annuleren
   edit: Pas aan
   delete: Verwijder
@@ -99,7 +102,6 @@ reglement-edit:
   edit: Wijzig bijlage
   return: Terug naar overzicht reglementaire bijlagen
   saving: Bezig met opslaan
-  confirm-leave-without-saving: Bent u zeker dat u deze pagina wilt verlaten zonder uw wijzigingen op te slaan?
   document-title-placeholder: Geef document-titel op
   insert-title: Document-titel invoegen
 auth:


### PR DESCRIPTION
## Overview
- Restructures the modal-route-leave so it shows an actual modal instead of a `window.confirm` box (which is more ugly and less accessible).
- also adds this logic for codelist form, where it was missing

##### connected issues and PRs:
https://binnenland.atlassian.net/browse/GN-4364

! The code is mainly based on work done in https://github.com/lblod/frontend-reglementaire-bijlage/pull/88/files#diff-4d405f6a17a3bc1e4537a824815deb278077401573a7af5229d973c0ffa3a7a1

### How to test/reproduce
go to the creation/editing of a regulatory statement, snippet (document, not snippet list) or codelist.
Make any change and try to navigate away via buttons or browser navigation. Make sure the modal shows up, the buttons work as expected and the history stays intact.

Note that refreshing or closing the tab can't be stopped and does not make the modal show up.

### Challenges/uncertainties
In the original idea, the modal was fully customizable (could pass any modal). However, with not using ember-promise-modals, this gives a lot of extra work and difficulties in understanding the flow. That's why for the implementation here, only the messages are customizable by passing them to the component (`@message` and `@confirmMessage`). This keeps the usage really simple (only `@enabled` is mandatory).
For now this is also more than enough, as currently no modal shows a custom message anyway...
