### PR TITLE
GN-4443: Update published snippet on snippet name change

### DIFF
--- a/app/components/app-chrome.js
+++ b/app/components/app-chrome.js
@@ -24,6 +24,10 @@ export default class AppChromeComponent extends Component {
   updateDocumentTitle = task(async (title) => {
     this.args.editorDocument.title = title;
     await this.args.editorDocument.save();
+
+    if (this.args.onUpdateDocumentTitle) {
+      await this.args.onUpdateDocumentTitle();
+    }
   });
 
   resetDocument = task(async () => {

--- a/app/controllers/snippets-management/edit/edit-snippet.js
+++ b/app/controllers/snippets-management/edit/edit-snippet.js
@@ -256,4 +256,17 @@ export default class SnippetsManagementEditSnippetController extends Controller 
 
     await this.muTask.waitForMuTaskTask.perform(publicationTask.id, 100);
   });
+
+  updateDocumentTitle = task(async () => {
+    const documentContainer = this.model;
+
+    const publicationTask = this.store.createRecord(
+      'snippet-list-publication-task',
+    );
+
+    publicationTask.documentContainer = documentContainer;
+    await publicationTask.save();
+
+    await this.muTask.waitForMuTaskTask.perform(publicationTask.id, 100);
+  });
 }

--- a/app/templates/snippets-management/edit/edit-snippet.hbs
+++ b/app/templates/snippets-management/edit/edit-snippet.hbs
@@ -7,6 +7,7 @@
   @documentContainer={{this.model}}
   @save={{hash action=(perform this.save) isRunning=this.save.isRunning}}
   @dirty={{this.dirty}}
+  @onUpdateDocumentTitle={{perform this.updateDocumentTitle}}
 />
 {{#if this.editorDocument}}
   <RdfaEditorContainer


### PR DESCRIPTION
### Overview

Updates published snippet when snippet name updated

#### Connected issues and PRs:

https://binnenland.atlassian.net/browse/GN-4443


### Setup

1. Get https://github.com/lblod/app-reglementaire-bijlage
2. Run `app-reglementaire-bijlage`
3. Checkout this branch
6. Inside `frontend-reglementaire-bijlage` do `npm i` and server it with `ember s --proxy http://localhost`

### How to test/reproduce

Modified `frontend-reglementaire-bijlage` should be running on localhost on port 4200.

* Go to http://localhost:4200/mock-login to login into RB frontend
* Create a Snippet List, and create a snippet within that list. Observe that all is working, snippet is saved and there are no console/network errors.
* Go to Regulatory Attachments and try to insert the snippet
* Go back to Snippet and rename it
* Go to Regulatory Attachments and see that Snippet name got changed (might be cached for a bit)





