### PR TITLE
Enable template comments on regulatory statement edit page

### DIFF
--- a/app/controllers/regulatory-attachments/edit.js
+++ b/app/controllers/regulatory-attachments/edit.js
@@ -64,6 +64,10 @@ import {
   text_variable,
 } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/variable-plugin/variables';
 import { document_title } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/document-title-plugin/nodes';
+import {
+  templateComment,
+  templateCommentView,
+} from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/template-comments-plugin';
 import { docWithConfig } from '@lblod/ember-rdfa-editor/nodes/doc';
 export default class EditController extends Controller {
   @service store;
@@ -88,6 +92,7 @@ export default class EditController extends Controller {
       list_item,
       ordered_list,
       bullet_list,
+      templateComment,
       placeholder,
       ...tableNodes({ tableGroup: 'block', cellContent: 'inline*' }),
       date: date(this.config.date),
@@ -220,6 +225,7 @@ export default class EditController extends Controller {
         number: numberView(controller),
         text_variable: textVariableView(controller),
         codelist: codelistView(controller),
+        templateComment: templateCommentView(controller),
       };
     };
   }

--- a/app/templates/regulatory-attachments/edit.hbs
+++ b/app/templates/regulatory-attachments/edit.hbs
@@ -102,6 +102,9 @@
               @controller={{this.editor}}
               @config={{this.config.snippet}}
             />
+            <TemplateCommentsPlugin::Insert
+              @controller={{this.editor}}
+            />
           </Sidebar.Collapsible>
           <VariablePlugin::InsertVariableCard
             @controller={{this.editor}}


### PR DESCRIPTION
## Overview
This PR adds the new template comments feature to the regulatory-statement edit page. It allows users to insert a comment/example in a template. This comment is to be removed upon publishing a regulatory statement.