### PR TITLE
GN-4425: Be less strict on the `doc` content

### DIFF
--- a/app/controllers/regulatory-attachments/edit.js
+++ b/app/controllers/regulatory-attachments/edit.js
@@ -83,7 +83,7 @@ export default class EditController extends Controller {
     nodes: {
       doc: docWithConfig({
         content:
-          'table_of_contents? document_title? ((chapter|block)+|(title|block)+|(article|block)+)',
+          'table_of_contents? document_title? (chapter|title|article|block)+',
       }),
       paragraph,
       document_title,

--- a/app/controllers/snippets-management/edit/edit-snippet.js
+++ b/app/controllers/snippets-management/edit/edit-snippet.js
@@ -82,7 +82,7 @@ export default class SnippetsManagementEditSnippetController extends Controller 
     nodes: {
       doc: docWithConfig({
         content:
-          'table_of_contents? document_title? ((chapter|block)+|(title|block)+|(article|block)+)',
+          'table_of_contents? document_title? (chapter|title|article|block)+',
       }),
       paragraph,
       document_title,


### PR DESCRIPTION
## Overview

Be less strict on what content is allowed and in what order in the `doc`.

#### Connected issues and PRs:

https://binnenland.atlassian.net/browse/GN-4425


### Setup

Checkout and launch

### How to test/reproduce

Create new Reg Attachment. Try to insert document title, then article. Observer that it is still possible to insert other structured nodes.

### Challenges/uncertainties

The structured wrapping logic still seems to be working correctly, tried to break it, didn't succeed.



### Checks PR readiness
- [x] UI: works on smaller screen sizes
- [x] UI: feedback for any loading/error states
- [x] Check cancel/go-back flows
- [x] Check database state correct when deleting/updating (especially regarding relationships)
- [x] changelog
- [x] npm lint
- [x] no new deprecations