### PR TITLE
Add translations to variable-insert dropdown

### DIFF
--- a/.changeset/fair-ties-rule.md
+++ b/.changeset/fair-ties-rule.md
@@ -1,0 +1,5 @@
+---
+'frontend-reglementaire-bijlage': patch
+---
+
+Add variable insert dropdown translations

--- a/app/controllers/regulatory-attachments/edit.js
+++ b/app/controllers/regulatory-attachments/edit.js
@@ -143,31 +143,31 @@ export default class EditController extends Controller {
     const config = getOwner(this).resolveRegistration('config:environment');
     return [
       {
-        label: 'text',
+        label: this.intl.t('editor.variables.text'),
         component: {
           path: 'variable-plugin/text/insert',
         },
       },
       {
-        label: 'number',
+        label: this.intl.t('editor.variables.number'),
         component: {
           path: 'variable-plugin/number/insert',
         },
       },
       {
-        label: 'address',
+        label: this.intl.t('editor.variables.address'),
         component: {
           path: 'variable-plugin/address/insert',
         },
       },
       {
-        label: 'date',
+        label: this.intl.t('editor.variables.date'),
         component: {
           path: 'variable-plugin/date/insert',
         },
       },
       {
-        label: 'codelist',
+        label: this.intl.t('editor.variables.codelist'),
         component: {
           path: 'variable-plugin/codelist/insert',
           options: {

--- a/app/controllers/snippets-management/edit/edit-snippet.js
+++ b/app/controllers/snippets-management/edit/edit-snippet.js
@@ -139,31 +139,31 @@ export default class SnippetsManagementEditSnippetController extends Controller 
     const config = getOwner(this).resolveRegistration('config:environment');
     return [
       {
-        label: 'text',
+        label: this.intl.t('editor.variables.text'),
         component: {
           path: 'variable-plugin/text/insert',
         },
       },
       {
-        label: 'number',
+        label: this.intl.t('editor.variables.number'),
         component: {
           path: 'variable-plugin/number/insert',
         },
       },
       {
-        label: 'date',
-        component: {
-          path: 'variable-plugin/date/insert',
-        },
-      },
-      {
-        label: 'address',
+        label: this.intl.t('editor.variables.address'),
         component: {
           path: 'variable-plugin/address/insert',
         },
       },
       {
-        label: 'codelist',
+        label: this.intl.t('editor.variables.date'),
+        component: {
+          path: 'variable-plugin/date/insert',
+        },
+      },
+      {
+        label: this.intl.t('editor.variables.codelist'),
         component: {
           path: 'variable-plugin/codelist/insert',
           options: {

--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -159,3 +159,10 @@ editor-document-title:
   placeholder: Untitled document
   change-title: Change title
   title-saved: Title saved
+editor:
+  variables:
+    text: text
+    number: number
+    address: address
+    date: date
+    codelist: codelist

--- a/translations/nl-BE.yaml
+++ b/translations/nl-BE.yaml
@@ -159,3 +159,10 @@ editor-document-title:
   placeholder: Naamloos document
   change-title: Titel wijzigen
   title-saved: Titel opgeslagen
+editor:
+  variables:
+    text: tekst
+    number: nummer
+    address: adres
+    date: datum
+    codelist: codelijst


### PR DESCRIPTION
## Overview
The entries in the insert-variable dropdown component were still hardcoded in english, this PR ensures that these are properly internationalized.

### How to test/reproduce
- Open a regulatory statement template/snippet
- Check if the variable-insert dropdown is properly internationalized

### Checks PR readiness
- [x] changelog
- [x] npm lint