### PR TITLE
Fix website url in footer (hotfix)

### DIFF
--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -124,7 +124,7 @@ reglementaire-bijlage-titel:
   placeholder: "Untitled document"
   modify: "Modify title"
 static-page:
-  official-website: reglementaire-bijlage.vlaanderen.be is an official website of the Flemish government
+  official-website: register.reglementairebijlagen.vlaanderen.be is an official website of the Flemish government
   published-by: Published by
   agentschap-binnenlands-bestuur: Agentschap Binnenlands Bestuur
   disclaimer: Disclaimer

--- a/translations/nl-BE.yaml
+++ b/translations/nl-BE.yaml
@@ -124,7 +124,7 @@ reglementaire-bijlage-titel:
   placeholder: Naamloos document
   modify: "Titel aanpassen"
 static-page:
-  official-website: reglementaire-bijlage.vlaanderen.be is een officiële website van de Vlaamse overheid
+  official-website: register.reglementairebijlagen.vlaanderen.be is een officiële website van de Vlaamse overheid
   published-by: Uitgegeven door
   agentschap-binnenlands-bestuur: Agentschap Binnenlands Bestuur
   disclaimer: Disclaimer


### PR DESCRIPTION
## Overview
This PR corrects the production website URL in the footer of this application to register.reglementairebijlagen.vlaanderen.be (hotfix to version 6.7.0)