### PR TITLE
Also save title when saving document + fix save pill and don't allow empty titles

### DIFF
--- a/.changeset/fair-geese-buy.md
+++ b/.changeset/fair-geese-buy.md
@@ -1,0 +1,8 @@
+---
+'frontend-reglementaire-bijlage': minor
+---
+
+- automatically save the document title if clicking outside of the title input box
+- Do not allow any empty document titles
+- saving a document will also save its title
+- the "saved" pill will only show up if something is actually saved

--- a/app/components/editor-document-title.hbs
+++ b/app/components/editor-document-title.hbs
@@ -33,7 +33,7 @@
       {{limit-content this.title 70}} 
       <AuButton {{on "click" this.enableEdit}} @icon="pencil" @skin="tertiary" @hideText={{true}} >{{t "editor-document-title.change-title"}}</AuButton>
     </h1>
-    {{#if this.showSaved}}
+    {{#if this.showIsSaved}}
       <AuPill
         @skin="success"
         @icon="check"

--- a/app/components/editor-document-title.hbs
+++ b/app/components/editor-document-title.hbs
@@ -5,10 +5,10 @@
 {{else}}
   {{#if this.active}}
     <form {{on 'submit' this.submit}} {{on "focusout" this.submit}}>
-      <div class="au-c-app-chrome__title-group {{if this.error "au-c-input--error"}}">
+      <div class="au-c-app-chrome__title-group">
         {{#let (unique-id) as |id|}}
             <input
-              class="au-c-app-chrome__title-input {{if this.error "au-c-input--error"}}"
+              class="au-c-app-chrome__title-input {{if this.isInvalidTitle "au-c-input--error"}}"
               placeholder={{t "editor-document-title.placeholder"}}
               id={{id}}
               type="text"
@@ -24,7 +24,7 @@
           @skin="secondary"
           @icon="check"
           @hideText={{true}}
-          @disabled={{not this.titleModified}}
+          @disabled={{this.isInvalidTitle}}
         >{{t "editor-document-title.change-title"}}</AuButton>
       </div>
     </form>

--- a/app/components/editor-document-title.hbs
+++ b/app/components/editor-document-title.hbs
@@ -33,7 +33,7 @@
       {{limit-content this.title 70}} 
       <AuButton {{on "click" this.enableEdit}} @icon="pencil" @skin="tertiary" @hideText={{true}} >{{t "editor-document-title.change-title"}}</AuButton>
     </h1>
-    {{#if this.showIsSaved}}
+    {{#if this.showIsSavedTask.isRunning}}
       <AuPill
         @skin="success"
         @icon="check"

--- a/app/components/editor-document-title.hbs
+++ b/app/components/editor-document-title.hbs
@@ -14,6 +14,7 @@
               type="text"
               value={{this.title}}
               {{on "input" this.setTitle}}
+              {{on "keydown" this.cancelOnEscape}}
               {{did-insert this.focus}}
             />
         {{/let}}

--- a/app/components/editor-document-title.hbs
+++ b/app/components/editor-document-title.hbs
@@ -4,7 +4,7 @@
   </h1>
 {{else}}
   {{#if this.active}}
-    <form {{on 'submit' this.submit}} {{on "focusout" this.cancel}}>
+    <form {{on 'submit' this.submit}} {{on "focusout" this.submit}}>
       <div class="au-c-app-chrome__title-group {{if this.error "au-c-input--error"}}">
         {{#let (unique-id) as |id|}}
             <input

--- a/app/components/editor-document-title.js
+++ b/app/components/editor-document-title.js
@@ -65,6 +65,13 @@ export default class EditorDocumentTitleComponent extends Component {
     this.disabledEdit();
   }
 
+  @action
+  cancelOnEscape(keyEvent) {
+    if (keyEvent.key === 'Escape') {
+      this.cancel();
+    }
+  }
+
   // We check the value of active in these 2 functions to avoid setting it 2 times in the same computation with
   // the cancel event + submit which cause a bug in prod environments.
   @action

--- a/app/components/editor-document-title.js
+++ b/app/components/editor-document-title.js
@@ -6,8 +6,9 @@ import { isBlank } from '../utils/strings';
 
 export default class EditorDocumentTitleComponent extends Component {
   @tracked active = false;
+  @tracked error = false;
   @tracked _title;
-  @tracked showIsSaved = false;
+
   constructor() {
     super(...arguments);
     this.active = this.args.editActive;
@@ -37,6 +38,10 @@ export default class EditorDocumentTitleComponent extends Component {
   setTitle(event) {
     let title = event.target.value;
     this._title = title;
+
+    if (title) {
+      this.error = false;
+    }
   }
 
   @action
@@ -48,14 +53,12 @@ export default class EditorDocumentTitleComponent extends Component {
     }
     this.args.onSubmit?.(this.title);
     this.disableEdit();
-    this.showIsSavedTask.perform;
+    this.showIsSavedTask.perform();
     return false;
   }
 
   showIsSavedTask = restartableTask(async () => {
-    this.showIsSaved = true;
     await timeout(3000);
-    this.showIsSaved = false;
   });
 
   @action
@@ -75,8 +78,7 @@ export default class EditorDocumentTitleComponent extends Component {
   // the cancel event + submit which cause a bug in prod environments.
   @action
   enableEdit() {
-    this.showIsSavedTask.cancel;
-    this.showIsSaved = false;
+    this.showIsSavedTask.cancelAll();
     if (this.active) {
       return;
     }

--- a/app/components/editor-document-title.js
+++ b/app/components/editor-document-title.js
@@ -6,7 +6,6 @@ import { isBlank } from '../utils/strings';
 
 export default class EditorDocumentTitleComponent extends Component {
   @tracked active = false;
-  @tracked error = false;
   @tracked _title;
   @tracked showIsSaved = false;
   constructor() {
@@ -38,10 +37,6 @@ export default class EditorDocumentTitleComponent extends Component {
   setTitle(event) {
     let title = event.target.value;
     this._title = title;
-
-    if (title) {
-      this.error = false;
-    }
   }
 
   @action

--- a/app/components/editor-document-title.js
+++ b/app/components/editor-document-title.js
@@ -8,7 +8,7 @@ export default class EditorDocumentTitleComponent extends Component {
   @tracked active = false;
   @tracked error = false;
   @tracked _title;
-  @tracked showSaved = false;
+  @tracked showIsSaved = false;
   constructor() {
     super(...arguments);
     this.active = this.args.editActive;
@@ -53,14 +53,14 @@ export default class EditorDocumentTitleComponent extends Component {
     }
     this.args.onSubmit?.(this.title);
     this.disableEdit();
-    this.showSaved = true;
-    setTimeout(() => (this.showSaved = false), 30000);
+    this.showIsSavedTask.perform;
     return false;
   }
 
-  hideSaved = restartableTask(async () => {
+  showIsSavedTask = restartableTask(async () => {
+    this.showIsSaved = true;
     await timeout(3000);
-    this.showSaved = false;
+    this.showIsSaved = false;
   });
 
   @action
@@ -80,7 +80,8 @@ export default class EditorDocumentTitleComponent extends Component {
   // the cancel event + submit which cause a bug in prod environments.
   @action
   enableEdit() {
-    this.showSaved = false;
+    this.showIsSavedTask.cancel;
+    this.showIsSaved = false;
     if (this.active) {
       return;
     }

--- a/app/components/editor-document-title.js
+++ b/app/components/editor-document-title.js
@@ -22,11 +22,9 @@ export default class EditorDocumentTitleComponent extends Component {
     }
   }
 
-  get titleModified() {
-    if (!this._title) {
-      return false;
-    }
-    return this.args.title !== this._title;
+  get isInvalidTitle() {
+    // do not allow empty titles
+    return isBlank(this.title);
   }
 
   @action
@@ -42,13 +40,12 @@ export default class EditorDocumentTitleComponent extends Component {
   @action
   submit(event) {
     event.preventDefault();
-    if (isBlank(this.title)) {
-      // do not allow any empty title
+    if (this.isInvalidTitle) {
       this.cancel();
       return;
     }
     this.args.onSubmit?.(this.title);
-    this.disabledEdit();
+    this.disableEdit();
     this.showSaved = true;
     setTimeout(() => (this.showSaved = false), 30000);
     return false;
@@ -62,7 +59,7 @@ export default class EditorDocumentTitleComponent extends Component {
   @action
   cancel() {
     this._title = undefined;
-    this.disabledEdit();
+    this.disableEdit();
   }
 
   @action
@@ -76,6 +73,7 @@ export default class EditorDocumentTitleComponent extends Component {
   // the cancel event + submit which cause a bug in prod environments.
   @action
   enableEdit() {
+    this.showSaved = false;
     if (this.active) {
       return;
     }
@@ -83,15 +81,11 @@ export default class EditorDocumentTitleComponent extends Component {
   }
 
   @action
-  disabledEdit() {
+  disableEdit() {
     if (!this.active) {
       return;
     }
-    if (!this.title) {
-      this.error = true;
-    } else {
-      this.active = false;
-    }
+    this.active = false;
   }
 
   @action

--- a/app/components/editor-document-title.js
+++ b/app/components/editor-document-title.js
@@ -22,6 +22,13 @@ export default class EditorDocumentTitleComponent extends Component {
     }
   }
 
+  get isTitleModified() {
+    if (!this._title) {
+      return false;
+    }
+    return this.args.title !== this._title;
+  }
+
   get isInvalidTitle() {
     // do not allow empty titles
     return isBlank(this.title);
@@ -40,7 +47,7 @@ export default class EditorDocumentTitleComponent extends Component {
   @action
   submit(event) {
     event.preventDefault();
-    if (this.isInvalidTitle) {
+    if (this.isInvalidTitle || !this.isTitleModified) {
       this.cancel();
       return;
     }

--- a/app/components/editor-document-title.js
+++ b/app/components/editor-document-title.js
@@ -2,6 +2,7 @@ import Component from '@glimmer/component';
 import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
 import { restartableTask, timeout } from 'ember-concurrency';
+import { isBlank } from '../utils/strings';
 
 export default class EditorDocumentTitleComponent extends Component {
   @tracked active = false;
@@ -41,6 +42,11 @@ export default class EditorDocumentTitleComponent extends Component {
   @action
   submit(event) {
     event.preventDefault();
+    if (isBlank(this.title)) {
+      // do not allow any empty title
+      this.cancel();
+      return;
+    }
     this.args.onSubmit?.(this.title);
     this.disabledEdit();
     this.showSaved = true;
@@ -54,11 +60,9 @@ export default class EditorDocumentTitleComponent extends Component {
   });
 
   @action
-  cancel(event) {
-    if (!event.currentTarget.contains(event.relatedTarget)) {
-      this._title = undefined;
-      this.disabledEdit();
-    }
+  cancel() {
+    this._title = undefined;
+    this.disabledEdit();
   }
 
   // We check the value of active in these 2 functions to avoid setting it 2 times in the same computation with

--- a/app/components/snippet-list-form.hbs
+++ b/app/components/snippet-list-form.hbs
@@ -14,7 +14,7 @@
         @value={{@model.label}}
         {{on "input" (perform this.updateLabel)}}
       />
-      {{#if this.showSaved}}
+      {{#if this.showSavedTask.isRunning}}
         <div class="snippets-pill-container">
           <AuPill
             @skin="success"

--- a/app/components/snippet-list-form.js
+++ b/app/components/snippet-list-form.js
@@ -13,11 +13,11 @@ export default class SnippetListForm extends Component {
   @service currentSession;
 
   @tracked label = '';
-  @tracked showSaved = false;
   @tracked isRemoveModalOpen = false;
   @tracked deletingSnippet;
 
   updateLabel = restartableTask(async (event) => {
+    this.showSavedTask.cancelAll();
     const value = event.target.value;
     this.args.model.label = value;
     if (this.invalidLabel) {
@@ -56,9 +56,7 @@ export default class SnippetListForm extends Component {
   }
 
   showSavedTask = restartableTask(async () => {
-    this.showSaved = true;
     await timeout(3000);
-    this.showSaved = false;
   });
 
   createSnippet = task(async () => {

--- a/app/controllers/regulatory-attachments/index.js
+++ b/app/controllers/regulatory-attachments/index.js
@@ -4,6 +4,7 @@ import { service } from '@ember/service';
 import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
 import { RS_STANDARD_FOLDER } from '../../utils/constants';
+import { isBlank } from '../../utils/strings';
 
 export default class ListController extends Controller {
   @service store;
@@ -43,6 +44,10 @@ export default class ListController extends Controller {
     this.editorDocument = undefined;
     this.documentContainer = undefined;
     this.createReglementModalIsOpen = false;
+  }
+
+  get isInvalidReglementTitle() {
+    return isBlank(this.editorDocument.title);
   }
 
   saveReglement = task(async (event) => {

--- a/app/templates/regulatory-attachments/index.hbs
+++ b/app/templates/regulatory-attachments/index.hbs
@@ -83,13 +83,14 @@
   </Modal.Body>
   <Modal.Footer>
     <AuButtonGroup>
-      <button
+      <AuButton
         class="au-c-button"
         form="create-meeting-form"
         type="submit"
+        @disabled={{this.isInvalidReglementTitle}}
       >
         {{t "regulatory-attachments.create-modal.save"}}
-      </button>
+      </AuButton>
       <AuButton {{on "click" this.cancelCreateReglement}} @skin="secondary">
         {{t "regulatory-attachments.create-modal.cancel"}}
       </AuButton>


### PR DESCRIPTION
## Overview
The initial problem to fix was to save the title also when saving the document.
Fixing this is not trivial in a sense: saving the title is deep in a child (EditorDocumentTitle) while saving the document is with an action passed to the main component.
However, as mentioned in the ticket, it is also desired to save when losing focus of the input (`onblur`). This automatically fixes the issue: if a user presses the document-save button, it will unblur the title input and automatically also save that.

This is the first commit.

All other commits are cleanup of code which this auto-save feature put into attention.

- Empty titles are not permitted (this was already not meant to be possible and was mentioned in a previous PR, but seems it got through anyway).
- Auto-saving didn't let the error show up. Now if a title is empty, it will show red and will not be saved
- save pill is only shown if something is actually saved
- save pill logic is a lot simpler and more logical, using the state of ember-concurrency, instead of keeping the exact same state ourselves.
- pressing escape cancels to editing of a title


##### connected issues and PRs:
https://binnenland.atlassian.net/browse/GN-4473
Similar changes are needed for GN (todo)

### How to test/reproduce
- try to save the title of a snippet or regulatory statement. See if it works as expected and save-pill does not show up if nothing was saved.
- It should never be possible to save an empty title.
- Pressing save for the document should also save the title.
- Press escape and see your title not being changed.

### Challenges/uncertainties
I noticed that spaces before a title are not really shown anywhere, but can exist. It might make sense to also trim the titles. A space at the start doesn't make sense anyway.
Should I also add this trimming?

