### PR TITLE
GN-4505 Generate attachment templates which maintain relationships between nodes

### DIFF
--- a/.changeset/fluffy-jeans-share.md
+++ b/.changeset/fluffy-jeans-share.md
@@ -1,0 +1,6 @@
+---
+'frontend-reglementaire-bijlage': major
+---
+
+Generate regulatory attachment templates which maintain relationships between nodes
+BREAKS import on GN unless updated to support generateBoundUuid

--- a/app/utils/generate-template.js
+++ b/app/utils/generate-template.js
@@ -17,14 +17,14 @@ export function generateTemplate(editor) {
     uris = [...uris, ...resourceUris];
   }
   let documentHTML = editor.htmlContent;
-  for (let uri of uris) {
+  uris.forEach((uri, index) => {
     const uriParts = uri.split('/');
     uriParts.pop();
     const uriWithoutUuid = uriParts.join('/');
-    documentHTML = documentHTML.replace(
+    documentHTML = documentHTML.replaceAll(
       uri,
-      `${uriWithoutUuid}/\${generateUuid()}`,
+      `${uriWithoutUuid}/\${generateBoundUuid(${index})}`,
     );
-  }
+  });
   return documentHTML;
 }


### PR DESCRIPTION
## Overview
All instances of one uri are replaced with the same call to `generateBoundUuid()`, so they will receive the same uri in the new document.
BREAKING: requires GN to support `generateBoundUuid()` (>5.7.0)

##### connected issues and PRs:
https://binnenland.atlassian.net/browse/GN-4505
Requires: https://github.com/lblod/frontend-gelinkt-notuleren/pull/586
Related: https://github.com/lblod/ember-rdfa-editor-lblod-plugins/pull/315

### Setup
To test import into GN, need to set `regulatoryStatementEndpoint` and `regulatoryStatementFileEndpoint` in config/environment.js in that project to point to your local RS.

### How to test/reproduce
Backwards compat can be tested by creating a template regulatory attachment and then instantiating it in [GN](https://github.com/lblod/frontend-gelinkt-notuleren/pull/586).
Maintaining relationships can be tested by duplicating parts of a template which include uris, for example by replacing L19 of app/utils/generate-template.js like so:
```diff
-  let documentHTML = editor.htmlContent;
+  let documentHTML = editor.htmlContent.slice(0, -6) + editor.htmlContent.replace('<div lang="nl-BE" data-say-document="true">', '');
``` 
then saving any template with uris (this will then duplicate the whole template, but within one outer `div`.
The output can be seen to have the same argument passed to `generateBoundUuid()` for the matching uris. This can also be instantiated in [GN with the correct PR](https://github.com/lblod/frontend-gelinkt-notuleren/pull/586)

### Challenges/uncertainties
It was unclear whether having separate generateUuids and generateBoundUuids functions was preferable to having just one function with an optional argument. Switching to just one overloaded function is trivial, but it's unclear if the current generateBoundUuids is used elsewhere already or not.

### Checks PR readiness
- [x] Check database state correct when deleting/updating (especially regarding relationships)
- [x] changelog
- [x] npm lint
- [x] no new deprecations