### PR TITLE
GN-4536: fill out legal pages

### DIFF
--- a/.changeset/polite-cars-lie.md
+++ b/.changeset/polite-cars-lie.md
@@ -1,0 +1,5 @@
+---
+'frontend-reglementaire-bijlage': minor
+---
+
+GN-4536: fill out legal pages

--- a/app/components/footer.hbs
+++ b/app/components/footer.hbs
@@ -1,0 +1,24 @@
+<AuMainFooter>
+  <AuHeading @level="3" @skin="4">
+    {{t "static-page.official-website"}}
+  </AuHeading>
+  <AuContent @skin="small">
+    <p>{{t "static-page.published-by"}}
+      <a
+        class="au-c-link"
+        href="https://www.vlaanderen.be/organisaties/administratieve-diensten-van-de-vlaamse-overheid/beleidsdomein-kanselarij-en-bestuur/agentschap-binnenlands-bestuur"
+      >{{t "static-page.agentschap-binnenlands-bestuur"}}</a>
+    </p>
+    <ul class="au-c-list-horizontal">
+      <li class="au-c-list-horizontal__item">
+        <AuLink @route="legal.disclaimer" @skin="secondary">{{t "static-page.disclaimer"}}</AuLink>
+      </li>
+      <li class="au-c-list-horizontal__item">
+        <AuLink @route="legal.cookiestatement" @skin="secondary">{{t "static-page.cookie-policy"}}</AuLink>
+      </li>
+      <li class="au-c-list-horizontal__item">
+        <AuLink @route="legal.accessibilitystatement" @skin="secondary">{{t "static-page.accesibility-statement"}}</AuLink>
+      </li>
+    </ul>
+  </AuContent>
+</AuMainFooter>

--- a/app/components/static-page.hbs
+++ b/app/components/static-page.hbs
@@ -6,27 +6,4 @@
 
 {{yield}}
 
-<AuMainFooter>
-  <AuHeading @level="3" @skin="4">
-    {{t "static-page.official-website"}}
-  </AuHeading>
-  <AuContent @skin="small">
-    <p>{{t "static-page.published-by"}}
-      <a
-        class="au-c-link"
-        href="https://www.vlaanderen.be/organisaties/administratieve-diensten-van-de-vlaamse-overheid/beleidsdomein-kanselarij-en-bestuur/agentschap-binnenlands-bestuur"
-      >{{t "static-page.agentschap-binnenlands-bestuur"}}</a>
-    </p>
-    <ul class="au-c-list-horizontal">
-      <li class="au-c-list-horizontal__item">
-        <AuLink @route="legal.disclaimer" @skin="secondary">{{t "static-page.disclaimer"}}</AuLink>
-      </li>
-      <li class="au-c-list-horizontal__item">
-        <AuLink @route="legal.cookiestatement" @skin="secondary">{{t "static-page.cookie-policy"}}</AuLink>
-      </li>
-      <li class="au-c-list-horizontal__item">
-        <AuLink @route="legal.accessibilitystatement" @skin="secondary">{{t "static-page.accesibility-statement"}}</AuLink>
-      </li>
-    </ul>
-  </AuContent>
-</AuMainFooter>
+<Footer/>

--- a/app/templates/legal.hbs
+++ b/app/templates/legal.hbs
@@ -1,0 +1,10 @@
+<AuMainContainer as |m|>
+  <m.content @scroll={{true}}>
+    <div class="au-o-region-large">
+      <div class="au-o-layout">
+        {{outlet}}
+      </div>
+    </div>
+    <Footer/>
+  </m.content>
+</AuMainContainer>

--- a/app/templates/legal/accessibilitystatement.hbs
+++ b/app/templates/legal/accessibilitystatement.hbs
@@ -1,2 +1,107 @@
-{{page-title (t "legal.accessibility-statement")}}
-{{outlet}}
+{{page-title (t 'legal.accessibility-statement')}}
+{{! template-lint-disable no-bare-strings  }}
+<AuContent class='au-u-3-4@medium'>
+  <AuHeading>Toegankelijkheidsverklaring</AuHeading>
+  <p>Agentschap Binnenlands Bestuur streeft ernaar zijn websites en mobiele
+    applicaties toegankelijk te maken, overeenkomstig het
+    <a
+      href='http://www.ejustice.just.fgov.be/eli/decreet/2018/12/07/2018032457/justel'
+      target='_blank'
+      rel='noopener noreferrer'
+    >Bestuursdecreet van 7 december 2018</a>.</p>
+  <p>Deze toegankelijkheidsverklaring is van toepassing op
+    <a
+      href='https://register.reglementairebijlagen.vlaanderen.be'
+    >register.reglementairebijlagen.vlaanderen.be</a></p>
+
+  <h2>Nalevingsstatus</h2>
+  <p>Deze web applicatie voldoet gedeeltelijk aan de
+    <a
+      href='https://www.w3.org/Translations/WCAG21-nl/'
+      target='_blank'
+      rel='noopener noreferrer'
+    >Richtlijnen voor Toegankelijkheid van Webcontent (WCAG) 2.1 Niveau AA</a>,
+    omdat niet aan de onderstaande eis(en) is voldaan.</p>
+
+  <h2>Niet-toegankelijke inhoud</h2>
+
+  <p>De onderstaande inhoud is niet-toegankelijk om de volgende reden(en):</p>
+  <ul>
+    <li>
+      <p><strong>Tekst editor:</strong>
+        slechts een deel van tekst editor functionaliteit, en diens plugins is
+        toegankelijk via het toetsenbord (<a
+          href='https://www.w3.org/Translations/WCAG21-nl/#toetsenbord-geen-uitzondering'
+          target='_blank'
+          rel='noopener noreferrer'
+        >Succescriterium 2.1.3 Toetsenbord</a>).</p>
+      <br />
+
+      <p><strong>Onevenredige last</strong></p>
+      <p>Hiervoor wordt de vrijstelling op grond van onevenredige last
+        ingeroepen, in de zin van
+        <a
+          href='https://eur-lex.europa.eu/legal-content/NL/ALL/?uri=CELEX%3A32016L2102#d1e807-1-1'
+          target='_blank'
+          rel='noreferrer noopener'
+        >artikel 5 van Richtlijn (EU) 2016/2102</a>
+        en art. II.16
+        <a
+          href='http://www.ejustice.just.fgov.be/eli/decreet/2018/12/07/2018032457/justel#Art.II.16'
+          target='_blank'
+          rel='noopener noreferrer'
+        >Bestuursdecreet van 7 december 2018</a>.</p>
+      <br />
+    </li>
+    <li>
+      <strong>Paginatitels:</strong>
+      Webpagina's hebben geen titels die het onderwerp of doel beschrijven. (<a
+        href='https://www.w3.org/Translations/WCAG21-nl/#paginatitel'
+        target='_blank'
+        rel='noopener noreferrer'
+      >Succescriterium 2.1.3 Toetsenbord</a>).
+      <br />
+      <em>Alternatief:</em>
+      er werd een "web page announcer" toegevoegd die zal aankondigen wanneer er
+      een nieuwe link bezocht wordt. De titel wordt nog niet aangekondigd.
+      <br />
+    </li>
+    <li>
+      <strong>Focus:</strong>
+      Niet elke gebruikersinterface die met een toetsenbord te bedienen is,
+      heeft een bedieningswijze waarbij de indicator van de toetsenbordfocus
+      zichtbaar is.. (<a
+        href='https://www.w3.org/Translations/WCAG21-nl/#focus-zichtbaar'
+        target='_blank'
+        rel='noopener noreferrer'
+      >Succescriterium 2.4.7 Focus zichtbaar</a>).
+      <br />
+    </li>
+  </ul>
+
+  <h2>Opstelling van deze toegankelijkheidsverklaring </h2>
+  <p>Deze toegankelijkheidsverklaring is opgesteld op 18/06/2021.</p>
+  <p>Voor deze toegankelijkheidsverklaring werd de toegankelijkheid van de
+    vermelde web applicatie beoordeeld door het Agentschap Binnenlands Bestuur.</p>
+
+  <h2>Feedback en contactgegevens</h2>
+  <p>Voor alle vragen en opmerkingen over de toegankelijkheid van de vermelde
+    websites van het Agentschap Binnenlands Bestuur kunt u contact opnemen via
+    <a href='mailto:binnenland@vlaanderen.be'>binnenland@vlaanderen.be</a></p>
+
+  <h2>Handhavingsprocedure</h2>
+  <p>Bij onbevredigende antwoorden op uw vragen en opmerkingen kunt u de Vlaamse
+    Ombudsdienst contacteren via onderstaande gegevens.</p>
+  <p>
+    <strong>Vlaamse Ombudsdienst</strong><br />
+    Leuvenseweg 86
+    <br />
+    1000 Brussel
+    <br />
+    <a href='mailto:info@vlaamseombudsdienst.be'>info@vlaamseombudsdienst.be</a>
+    <br />
+    Telefoon (gratis):
+    <a href='tel:info@vlaamseombudsdienst.be'>1700</a>
+    <br />
+  </p>
+</AuContent>

--- a/app/templates/legal/cookiestatement.hbs
+++ b/app/templates/legal/cookiestatement.hbs
@@ -1,2 +1,45 @@
 {{page-title (t "legal.cookie-statement")}}
-{{outlet}}
+{{!-- template-lint-disable no-bare-strings  --}}
+<AuContent class="au-u-3-4@medium">
+  <AuHeading>Cookieverklaring</AuHeading>
+  <h2>Cookiebeleid van Agentschap Binnenlands Bestuur</h2>
+  <p>Agentschap Binnenlands Bestuur met maatschappelijke zetel te Havenlaan 88, 1000 Brussel is verantwoordelijk voor dit cookiebeleid. Agentschap Binnenlands Bestuur vindt het belangrijk dat u op iedere plaats en elk ogenblik haar content kan bekijken, beluisteren, lezen of beleven via diverse mediaplatformen. Agentschap Binnenlands Bestuur wil ook werken aan interactieve diensten en diensten op uw maat. Op Agentschap Binnenlands Bestuur-onlinediensten worden technieken gehanteerd om dit mogelijk te maken, bijvoorbeeld met behulp van cookies&nbsp;en&nbsp;scripts. Deze technieken worden hierna gemakelijkheidshalve cookies genoemd.</p>
+  <p>In dit cookiebeleid wenst Agentschap Binnenlands Bestuur u te informeren welke cookies worden gebruikt en waarom dit gebeurt. Verder wordt toegelicht in welke mate u als gebruiker het gebruik kan controleren. Agentschap Binnenlands Bestuur wil namelijk graag uw privacy en de gebruiksvriendelijkheid van haar onlinediensten zoveel mogelijk waarborgen. Agentschap Binnenlands Bestuur heeft geprobeerd dit beleid zo eenvoudig mogelijk te houden.</p>
+  <p>Agentschap Binnenlands Bestuur kan het cookiebeleid&nbsp;op elk moment veranderen. Dat kan bijvoorbeeld gebeuren in het kader van veranderingen aan haar diensten of de geldende wetgeving. Het gewijzigde beleid wordt dan bekendgemaakt op de relevante Agentschap Binnenlands Bestuur-onlinediensten en gelden vanaf het moment dat deze bekendgemaakt wordt.&nbsp;</p>
+  <h3>Wat zijn cookies precies?</h3>
+  <p>Cookies zijn kleine gegevens- of tekstbestanden die op uw computer of mobiele apparaat zijn geïnstalleerd wanneer u een website bezoekt of een (mobiele) toepassing gebruikt. Het cookiebestand bevat een unieke code waarmee u uw browser kunt herkennen tijdens het bezoek aan de online service of tijdens opeenvolgende, herhaalde bezoeken. Cookies kunnen worden geplaatst door de server van de website of applicatie die u bezoekt, maar ook door servers van derden die al dan niet met deze website of applicatie samenwerken.</p>
+  <p>Cookies maken over het algemeen de interactie tussen de bezoeker en de website of applicatie gemakkelijker en sneller en helpen de bezoeker om te navigeren tussen de verschillende delen van een website of applicatie.</p>
+  <h3 class="h3">Hoe kan u het gebruik van cookies weigeren of beheren?</h3>
+  <p>U kunt de installatie van cookies weigeren via uw browserinstellingen. U kunt op elk gewenst moment ook de reeds geïnstalleerde cookies van uw computer of mobiele apparaat verwijderen, als volgt:</p>
+  <ul><li>Internet Explorer: https://support.microsoft.com/nl-be/help/17479/windows-internet-explorer-11-change-security-privacy-settings&nbsp;</li>
+    <li>Chrome:&nbsp;http://support.google.com/chrome/bin/answer.py?hl=nl&amp;answer=95647&nbsp;</li>
+    <li>Firefox:&nbsp;http://support.mozilla.org/nl/kb/cookies-in-en-uitschakelen-websites-voorkeuren?redirectlocale=nl&amp;redirectslug=Cookies+in-+en+uitschakelen&nbsp;</li>
+    <li>Safari:&nbsp;http://support.apple.com/kb/PH5042&nbsp;</li>
+  </ul><p>Wanneer u cookies uitschakelt, moet u er rekening mee houden dat bepaalde grafische elementen er misschien niet mooi uitzien, of dat u bepaalde toepassingen niet kunt gebruiken. Hieronder vindt u een gedetailleerde lijst van de soorten cookies die op de website gebruikt worden.</p>
+  <h3 class="h3">Gebruikte cookies</h3>
+  <ul>
+    <li>Sessiebeheer
+      <ul><li>Naam van cookie: proxy_session</li>
+        <li>Doel: identificatie van de gebruikerssessie. De cookie wordt gezet door de mu-identifier component van het mu.semte.ch platform.</li>
+        <li>Cookie(s) geplaatst door:&nbsp;Vlaamse overheid</li>
+        <li>Ontvangers van de gegevens: Vlaamse overheid</li>
+        <li>Geldigheid: duur van de sessie</li>
+      </ul>
+    </li>
+    <li>Reverse proxy
+      <ul><li>Naam van cookie: VOGANONUSER</li>
+        <li>Doel: de Reverse Proxy van de Vlaamse overheid plaats dit cookie op Vlaanderen.be om de goede uitvoering van de verzending van communicatie over een elektronisch communicatienetwerk van de Vlaamse overheid te verzekeren.</li>
+        <li>Cookie(s) geplaatst door:&nbsp;Vlaamse overheid</li>
+        <li>Ontvangers van de gegevens: Vlaamse overheid</li>
+        <li>Geldigheid: permanente cookies met een geldigheid van maximaal 24 uur</li>
+      </ul>
+    </li>
+    <li>Meten van gebruikersbezoek
+      <ul><li>Namen van cookies: _ga, _gid, _gat en _umtz, _umta en&nbsp;gaClientId</li>
+        <li>Doel: Het gebruikersbezoek op Vlaanderen.be wordt via Google Universal Analytics op geanonimiseerde gemeten om het informatieaanbod op Vlaanderen.be te optimaliseren.&nbsp;De analytics cookies wordt via de Global header en footer widget op Vlaanderen.be geplaatst. Google Analytics is zo ingesteld dat het IP-adres niet wordt verwerkt, noch gegegens worden gedeeld</li>
+        <li>Cookie(s) geplaatst door:&nbsp;De analytics cookies worden geplaatst via het Widgets-platform dat de global header en footer aanbiedt (widgets.vlaanderen.be) en niet rechtsreeks door Google.com. Het Widgets-platform maakt hiervoor gebruik van het Google analytics object om zelf ClientID's aan te maken.</li>
+        <li>Ontvanger(s) van de gegevens: Google</li>
+        <li>Geldigheid: permanente cookies met een geldigheid van maximaal 2 jaar</li>
+      </ul></li>
+  </ul>
+</AuContent>

--- a/app/templates/legal/disclaimer.hbs
+++ b/app/templates/legal/disclaimer.hbs
@@ -1,2 +1,17 @@
 {{page-title (t "legal.disclaimer")}}
-{{outlet}}
+{{!-- template-lint-disable no-bare-strings  --}}
+<AuContent class="au-u-3-4@medium">
+  <AuHeading>Disclaimer</AuHeading>
+  <h2>Gebruik van de website</h2>
+  <p>De Vlaamse overheid besteedt veel aandacht en zorg aan haar websites, en streeft ernaar dat alle informatie zo volledig, juist, begrijpelijk, nauwkeurig en actueel mogelijk is. Ondanks alle inspanningen kan het gebeuren dat de informatie niet volledig, juist, nauwkeurig, bijgewerkt is of wordt weergegeven.</p>
+  <p>Als de informatie die u vindt op deze website of ontvangt via telefoon, e-mail of sociale media tekortkomingen vertoont, zal de Vlaamse overheid al het mogelijke doen om dat zo snel mogelijk recht te zetten. Als u onjuistheden vaststelt, kan u met ons contact opnemen. Wij streven ernaar om uw melding zo snel mogelijk te behandelen. De Vlaamse overheid spant zich ook in om onderbrekingen van technische aard zo veel mogelijk te voorkomen. De Vlaamse overheid kan echter niet garanderen dat de websit volledig vrij is van onderbrekingen en andere technische problemen.</p>
+  <p>Het is mogelijk dat bepaalde inhoud van onze website kan gedownload worden. Dit is steeds op eigen risico. Schade ten gevolge van verlies van data of schade aan de computer valt volledig en uitsluitend onder de verantwoordelijkheid van de gebruiker.</p>
+  <p>Derden, bezoekers aan de website en gebruikers van diensten moeten zich onthouden van handelingen die het gebruik van de website in gevaar kunnen brengen. Stel dat een dergelijke handelingen die goede werkingen en/of het veilige karakter van de website en/of haar diensten in gedrang breng en/of tot de gebrekkige toegankelijkheid.</p>
+  <h3>Inhoud en informatie op de website</h3>
+  <p>We besteden grote zorg aan de website en de informatie die erop staat. We kunnen onze website en haar inhoud steeds wijzigen, aanvullen of verwijderen. Toch kunnen we geen garanties geven omtrent de kwaliteit van de informatie op onze website. Het is dus mogelijk dat de informatie onvolledig is, niet accuraat en/of niet nuttig is. We zijn bijgevolg niet aansprakelijk voor directe of indirecte schade ten gevolge van handelingen die de gebruiken of bezoeker neemt op basis van de informatie op onze website. Zo verschijnt er op de website ook informatie en bestanden afkomstig van derde partijen. Deze derde partijen zijn zelf verantwoordelijk voor de kwaliteit van deze inhoud en bestanden.</p>
+  <h3>Hyperlinks en verwijzingen</h3>
+  <p>Deze site bevat hyperlinks naar websites van andere overheden, instanties en organisaties, en naar informatiebronnen die door derden worden beheerd. De Vlaamse overheid beschikt voor deze sites over geen enkele technische of inhoudelijke controle of zeggenschap en kan daarom geen enkele garantie bieden over de volledigheid of juistheid van de inhoud en over de beschikbaarheid van de websites en informatiebronnen.</p>
+
+  <h2>Bescherming van persoonsgegegevens</h2>
+  <p>De Vlaamse overheid hecht veel belang aan de bescherming van uw persoonlijke levenssfeer. De gegevens worden steeds verwerkt in overeenstemming met de bepalingen van de algemene verordening gegevensbescherming (AVG), en met de bepalingen van de federale en Vlaamse regelgeving over de bescherming van natuurlijke personen bij de verwerking van persoonsgegevens.</p>
+</AuContent>


### PR DESCRIPTION
## Overview
This PR ensures that the legal pages of this application (the accessibility statement, cookiestatement and disclaimer) are filled out.

##### connected issues and PRs:
[GN-4563](https://binnenland.atlassian.net/browse/GN-4536?atlOrigin=eyJpIjoiZDZmNTVlOGRjYTIxNGQzNWE1YWQyMjQwZDA2NjcwZTkiLCJwIjoiaiJ9)

### How to test/reproduce
- start the application
- check out the legal pages (linked in the footer)
- ensure that the text on the legal pages is displayed correctly

### Challenges/uncertainties
- I took over the content of the legal pages from the [GN](https://github.com/lblod/frontend-gelinkt-notuleren) application including some modifications. 

### Checks PR readiness
- [x] UI: works on smaller screen sizes
- [x] UI: feedback for any loading/error states
- [x] Check cancel/go-back flows
- [x] Check database state correct when deleting/updating (especially regarding relationships)
- [x] changelog
- [x] npm lint
- [x] no new deprecations