### PR TITLE
GN-4628: Change attribute name used to store snippet list IDs

### DIFF
--- a/.changeset/small-seals-talk.md
+++ b/.changeset/small-seals-talk.md
@@ -1,0 +1,7 @@
+---
+"frontend-reglementaire-bijlage": patch
+---
+
+GN-4628: Change attribute name used to store snippet list IDs
+
+`snippet-list-ids` was not a valid attribute name. Changed to `data-snippet-list-ids`.  

--- a/app/controllers/regulatory-attachments/edit.js
+++ b/app/controllers/regulatory-attachments/edit.js
@@ -75,7 +75,7 @@ import DateInsertVariableComponent from '@lblod/ember-rdfa-editor-lblod-plugins/
 import CodelistInsertComponent from '@lblod/ember-rdfa-editor-lblod-plugins/components/variable-plugin/codelist/insert';
 import VariablePluginAddressInsertVariableComponent from '@lblod/ember-rdfa-editor-lblod-plugins/components/variable-plugin/address/insert-variable';
 
-const SNIPPET_LISTS_IDS_DOCUMENT_ATTRIBUTE = 'snippet-list-ids';
+const SNIPPET_LISTS_IDS_DOCUMENT_ATTRIBUTE = 'data-snippet-list-ids';
 
 export default class EditController extends Controller {
   @service store;


### PR DESCRIPTION
## Overview

GN-4628: Change attribute name used to store snippet list IDs

`snippet-list-ids` was not a valid attribute name. Changed to `data-snippet-list-ids`.

##### connected issues and PRs:

https://binnenland.atlassian.net/browse/GN-4628


### Setup

1. Checkout

### How to test/reproduce

Open up http://localhost:4200/mock-login and try to perform the same activities as in linked video.

https://share.cleanshot.com/v3YsRvbh

### Checks PR readiness
- [X] UI: works on smaller screen sizes
- [X] UI: feedback for any loading/error states
- [X] Check cancel/go-back flows
- [X] Check database state correct when deleting/updating (especially regarding relationships)
- [X] changelog
- [X] npm lint
- [X] no new deprecations