### PR TITLE
Add translation for 'insert' in the sidebar

### DIFF
--- a/.changeset/lovely-queens-kiss.md
+++ b/.changeset/lovely-queens-kiss.md
@@ -1,0 +1,5 @@
+---
+"frontend-reglementaire-bijlage": patch
+---
+
+Correctly translate 'insert' in the sidebar

--- a/app/templates/regulatory-attachments/edit.hbs
+++ b/app/templates/regulatory-attachments/edit.hbs
@@ -94,7 +94,7 @@
     <:aside>
       {{#if this.editor}}
         <Sidebar as |Sidebar|>
-          <Sidebar.Collapsible @title='Insert' @expandedInitially={{true}}>
+          <Sidebar.Collapsible @title={{t "utility.insert"}} @expandedInitially={{true}}>
             <DocumentTitlePlugin::InsertTitleCard @controller={{this.editor}} />
             <ArticleStructurePlugin::ArticleStructureCard
               @controller={{this.editor}}

--- a/app/templates/snippets-management/edit/edit-snippet.hbs
+++ b/app/templates/snippets-management/edit/edit-snippet.hbs
@@ -75,7 +75,7 @@
     <:aside>
       {{#if this.editor}}
         <Sidebar as |Sidebar|>
-          <Sidebar.Collapsible @title='Insert' @expandedInitially={{true}}>
+          <Sidebar.Collapsible @title={{t "utility.insert"}} @expandedInitially={{true}}>
             <DocumentTitlePlugin::InsertTitleCard @controller={{this.editor}} />
             <ArticleStructurePlugin::ArticleStructureCard
               @controller={{this.editor}}

--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -59,6 +59,7 @@ utility:
   optional: Optional
   field-required: This field is required
   type-something-placeholder: Type something...
+  insert: Insert
 landing-page:
   create-reglement:
     title: Regulatory Attachments

--- a/translations/nl-BE.yaml
+++ b/translations/nl-BE.yaml
@@ -59,6 +59,7 @@ utility:
   optional: Optioneel
   field-required: Dit veld is verplicht
   type-something-placeholder: Typ iets...
+  insert: Invoegen
 landing-page:
   create-reglement:
     title: Reglementaire bijlagen


### PR DESCRIPTION
### Overview
In the sidebar, this used to say 'Insert':
![image](https://github.com/lblod/frontend-gelinkt-notuleren/assets/1323250/ecdc73e9-c4fb-47e4-a975-55072f274ec0)

##### connected issues and PRs:
https://binnenland.atlassian.net/browse/GN-4665

### Setup
Recommended, some way to change locales easily, e.g. [this extension](https://addons.mozilla.org/en-US/firefox/addon/locale-switcher/)

### How to test/reproduce
Open any regulatory attachment and confirm that the word 'insert' is in the correct language (NL for anything but locale of en-US).

### Challenges/uncertainties
I don't know the correct dutch and there seems to be difference with the `insert-label` translation.

### Checks PR readiness
- [x] UI: works on smaller screen sizes
- [x] UI: feedback for any loading/error states
- [x] Check cancel/go-back flows
- [x] Check database state correct when deleting/updating (especially regarding relationships)
- [x] changelog
- [x] npm lint
- [x] no new deprecations