### PR TITLE
Copy logic of using undo state to determine if there are unsaved changes

### DIFF
--- a/.changeset/rich-deers-double.md
+++ b/.changeset/rich-deers-double.md
@@ -1,0 +1,5 @@
+---
+"frontend-reglementaire-bijlage": minor
+---
+
+Correctly track the saved state of attachments and snippets so we only ask to save changes when changes have been made

--- a/app/controllers/regulatory-attachments/edit.js
+++ b/app/controllers/regulatory-attachments/edit.js
@@ -69,6 +69,7 @@ import {
   templateCommentView,
 } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/template-comments-plugin';
 import { docWithConfig } from '@lblod/ember-rdfa-editor/nodes/doc';
+import { undo } from '@lblod/ember-rdfa-editor/plugins/history';
 import TextVariableInsertComponent from '@lblod/ember-rdfa-editor-lblod-plugins/components/variable-plugin/text/insert';
 import NumberInsertComponent from '@lblod/ember-rdfa-editor-lblod-plugins/components/variable-plugin/number/insert';
 import DateInsertVariableComponent from '@lblod/ember-rdfa-editor-lblod-plugins/components/variable-plugin/date/insert-variable';
@@ -82,7 +83,6 @@ export default class EditController extends Controller {
   @service router;
   @tracked editor;
   @tracked _editorDocument;
-  @tracked controller;
   @service intl;
   @service currentSession;
   @tracked citationPlugin = citationPlugin(this.config.citation);
@@ -254,7 +254,11 @@ export default class EditController extends Controller {
   }
 
   get dirty() {
-    return this.editorDocument.content !== this.editor.htmlContent;
+    // Since we clear the undo history when saving, this works. If we want to maintain undo history
+    // on save, we would need to add functionality to the editor to track what is the 'saved' state
+    return this.editor?.checkCommand(undo, {
+      view: this.editor?.mainEditorView,
+    });
   }
 
   get editorDocument() {

--- a/app/controllers/snippets-management/edit/edit-snippet.js
+++ b/app/controllers/snippets-management/edit/edit-snippet.js
@@ -70,6 +70,7 @@ import {
   templateCommentView,
 } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/template-comments-plugin';
 import { docWithConfig } from '@lblod/ember-rdfa-editor/nodes/doc';
+import { undo } from '@lblod/ember-rdfa-editor/plugins/history';
 
 import TextVariableInsertComponent from '@lblod/ember-rdfa-editor-lblod-plugins/components/variable-plugin/text/insert';
 import NumberInsertComponent from '@lblod/ember-rdfa-editor-lblod-plugins/components/variable-plugin/number/insert';
@@ -82,7 +83,6 @@ export default class SnippetsManagementEditSnippetController extends Controller 
   @service router;
   @tracked editor;
   @tracked _editorDocument;
-  @tracked controller;
   @service intl;
   @service currentSession;
   @tracked citationPlugin = citationPlugin(this.config.citation);
@@ -246,7 +246,11 @@ export default class SnippetsManagementEditSnippetController extends Controller 
   }
 
   get dirty() {
-    return this.editorDocument.content !== this.editor?.htmlContent;
+    // Since we clear the undo history when saving, this works. If we want to maintain undo history
+    // on save, we would need to add functionality to the editor to track what is the 'saved' state
+    return this.editor?.checkCommand(undo, {
+      view: this.editor?.mainEditorView,
+    });
   }
 
   currentVersion = trackedFunction(this, async () => {

--- a/app/templates/regulatory-attachments/edit.hbs
+++ b/app/templates/regulatory-attachments/edit.hbs
@@ -13,6 +13,7 @@
     @editorDocument={{this.editorDocument}}
     @documentContainer={{this.model.documentContainer}}
     @save={{hash action=(perform this.save) isRunning=this.save.isRunning}}
+    @dirty={{this.dirty}}
     @publish={{hash
       action=(perform this.publish)
       isRunning=this.save.isRunning


### PR DESCRIPTION
## Overview
Use the new logic from [GN](https://github.com/lblod/frontend-gelinkt-notuleren/pull/614) of using the undo state to determine if there are unsaved changes.

I also fixed the display of 'there are unsaved changes' for attachments as this was not wired in.

##### connected issues and PRs:
[PR on GN](https://github.com/lblod/frontend-gelinkt-notuleren/pull/614)
https://binnenland.atlassian.net/browse/GN-4016

### Setup
N/A

### How to test/reproduce
Open a regulatory attachment or snippet, make an edit (or not), then attempt to leave.

### Challenges/uncertainties
N/A

### Checks PR readiness
- [x] UI: works on smaller screen sizes
- [x] UI: feedback for any loading/error states
- [x] Check cancel/go-back flows
- [x] Check database state correct when deleting/updating (especially regarding relationships)
- [x] changelog
- [x] npm lint
- [x] no new deprecations