### PR TITLE
GN-4654: add editor styling to template previews

### DIFF
--- a/.changeset/quick-news-shave.md
+++ b/.changeset/quick-news-shave.md
@@ -1,0 +1,5 @@
+---
+"frontend-reglementaire-bijlage": patch
+---
+
+Add editor styling to previews of templates

--- a/app/templates/regulatory-attachments/publish.hbs
+++ b/app/templates/regulatory-attachments/publish.hbs
@@ -27,7 +27,7 @@
           </c.header>
           <c.content>
             <div
-              class='say-editor rdfa-annotations rdfa-annotations-highlight rdfa-annotations-hover'
+              class='say-editor say-content rdfa-annotations rdfa-annotations-highlight rdfa-annotations-hover'
             >
               {{! template-lint-disable no-triple-curlies }}
               {{{this.model.templateVersion}}}
@@ -47,7 +47,7 @@
               <AuLoader />
             {{else}}
               <div
-                class='say-editor rdfa-annotations rdfa-annotations-highlight rdfa-annotations-hover'
+                class='say-editor say-content rdfa-annotations rdfa-annotations-highlight rdfa-annotations-hover'
               >
                 {{! template-lint-disable no-triple-curlies }}
                 {{{this.currentVersion}}}


### PR DESCRIPTION
## Overview
This PR adds the `say-content` class to the template previews in order to include editor styling.

##### connected issues and PRs:
Solves [GN-4654](https://binnenland.atlassian.net/browse/GN-4654?atlOrigin=eyJpIjoiZjNhN2E1OTRiZDY5NDU4OTk2NTYyMzI3YTFhZDU4ZWEiLCJwIjoiaiJ9) partly

### How to test/reproduce
- Open a template
- Insert an ordered list
- On the preview page, notice that the list numbers show up

### Checks PR readiness
- [x] UI: works on smaller screen sizes
- [x] UI: feedback for any loading/error states
- [x] Check cancel/go-back flows
- [x] Check database state correct when deleting/updating (especially regarding relationships)
- [x] changelog
- [x] npm lint
- [x] no new deprecations