### PR TITLE
GN-4733: fix node is `undefined` error

### DIFF
--- a/.changeset/soft-baboons-fry.md
+++ b/.changeset/soft-baboons-fry.md
@@ -1,0 +1,5 @@
+---
+"frontend-reglementaire-bijlage": patch
+---
+
+Fix issue with undefined error of snippet-insert component

--- a/app/templates/regulatory-attachments/edit.hbs
+++ b/app/templates/regulatory-attachments/edit.hbs
@@ -116,11 +116,13 @@
               @plugin={{this.citationPlugin}}
               @config={{this.config.citation}}
             />
-            <this.SnippetInsert
-              @controller={{this.editor}}
-              @config={{this.config.snippet}}
-              @node={{this.activeNode}}
-            />
+            {{#if this.activeNode}}
+              <this.SnippetInsert
+                @controller={{this.editor}}
+                @config={{this.config.snippet}}
+                @node={{this.activeNode}}
+              />
+            {{/if}}
             <TemplateCommentsPlugin::Insert @controller={{this.editor}} />
             <VariablePlugin::Address::Insert @controller={{this.editor}} />
           </Sidebar.Collapsible>


### PR DESCRIPTION
## Overview
This PR adds a null-check to the `activeNode` property before passing it to the `SnippetInsert` component, to ensure that we're not passing an undefined node to the component.

##### connected issues and PRs:
[GN-4733](https://binnenland.atlassian.net/browse/GN-4733?atlOrigin=eyJpIjoiYTZlYWU0Y2ZiOThiNDBkZDgxMWYyNjc5NmQzNmFjMzkiLCJwIjoiaiJ9)

### How to test/reproduce
- Start the application
- Open a regulatory statement in which snippet lists are active/allowed
- Click on a (citation) link
- Notice that no `node` is undefined error shows up

### Checks PR readiness
- [x] UI: works on smaller screen sizes
- [x] UI: feedback for any loading/error states
- [x] Check cancel/go-back flows
- [x] Check database state correct when deleting/updating (especially regarding relationships)
- [x] changelog
- [x] npm lint
- [x] no new deprecations