### PR TITLE
Ensure breadcrumbs toolbar is only shown when applicable

### DIFF
--- a/.changeset/cuddly-poems-kneel.md
+++ b/.changeset/cuddly-poems-kneel.md
@@ -1,0 +1,5 @@
+---
+"frontend-reglementaire-bijlage": patch
+---
+
+Hide breadcrumbs toolbar when not authenticated or on index page

--- a/app/controllers/application.js
+++ b/app/controllers/application.js
@@ -7,6 +7,7 @@ export default class ApplicationController extends Controller {
   @service store;
   @service session;
   @service currentSession;
+  @service router;
 
   @action
   logout() {
@@ -22,6 +23,12 @@ export default class ApplicationController extends Controller {
     return (
       this.environmentName !== '' &&
       this.environmentName !== '{{ENVIRONMENT_NAME}}'
+    );
+  }
+
+  get showBreadcrumbsToolbar() {
+    return (
+      this.session.isAuthenticated && this.router.currentRouteName !== 'index'
     );
   }
 }

--- a/app/templates/application.hbs
+++ b/app/templates/application.hbs
@@ -42,6 +42,7 @@
   </AuMainHeader>
   <AuMainContainer class='header-main-container' as |m|>
     <m.content scroll={{false}}>
+      {{#if this.showBreadcrumbsToolbar}}
       <AuToolbar
         @border='bottom'
         @size='medium'
@@ -62,6 +63,7 @@
           </BreadcrumbsContainer>
         </Group>
       </AuToolbar>
+      {{/if}}
       {{outlet}}
     </m.content>
   </AuMainContainer>


### PR DESCRIPTION
## Overview
This PR ensures that the breadcrumbs toolbar is not shown in the following cases:
- When on the index page
- When not authenticated

##### connected issues and PRs:
None

### How to test/reproduce
- Start up the frontend
- On the index/login page, the breadcrumbs toolbar should not be visible
- Once logged in, the toolbar should be visible on any other page

### Checks PR readiness
- [x] UI: works on smaller screen sizes
- [x] UI: feedback for any loading/error states
- [x] Check cancel/go-back flows
- [x] Check database state correct when deleting/updating (especially regarding relationships)
- [x] changelog
- [x] npm lint
- [x] no new deprecations