### PR TITLE
Drop ember-data `task` models

### DIFF
--- a/.changeset/loud-cows-fetch.md
+++ b/.changeset/loud-cows-fetch.md
@@ -1,0 +1,5 @@
+---
+"frontend-reglementaire-bijlage": patch
+---
+
+Drop ember-data `task` models

--- a/app/controllers/regulatory-attachments/publish.js
+++ b/app/controllers/regulatory-attachments/publish.js
@@ -31,12 +31,29 @@ export default class PublishController extends Controller {
 
   createPublishedResource = task(async () => {
     this.showPublishingModal = false;
-    const publicationTask = this.store.createRecord(
-      'regulatory-attachment-publication-task',
+    const body = {
+      data: {
+        relationships: {
+          'document-container': {
+            data: {
+              id: this.model.container.id,
+            },
+          },
+        },
+      },
+    };
+
+    const taskId = await this.muTask.fetchTaskifiedEndpoint(
+      '/regulatory-attachment-publication-tasks',
+      {
+        method: 'POST',
+        body: JSON.stringify(body),
+        headers: {
+          'Content-Type': 'application/vnd.api+json',
+        },
+      },
     );
-    publicationTask.documentContainer = this.model.container;
-    await publicationTask.save();
-    await this.muTask.waitForMuTaskTask.perform(publicationTask.id, 100);
+    await this.muTask.waitForMuTaskTask.perform(taskId, 100);
     await this.fetchPreview.perform();
     this.toaster.success(
       this.intl.t('publish-page.notification-content'),

--- a/app/controllers/snippets-management/edit/edit-snippet.js
+++ b/app/controllers/snippets-management/edit/edit-snippet.js
@@ -280,29 +280,38 @@ export default class SnippetsManagementEditSnippetController extends Controller 
     const documentContainer = this.model.documentContainer;
     documentContainer.currentVersion = editorDocument;
     await documentContainer.save();
-
-    const publicationTask = this.store.createRecord(
-      'snippet-list-publication-task',
-    );
-    publicationTask.documentContainer = documentContainer;
-    publicationTask.snippetList = this.model.snippetList;
-    await publicationTask.save();
-
-    await this.muTask.waitForMuTaskTask.perform(publicationTask.id, 100);
+    await this.publishSnippet.perform();
   });
 
-  updateDocumentTitle = task(async () => {
-    const documentContainer = this.model.documentContainer;
-    const snippetList = this.model.snippetList;
+  publishSnippet = task(async () => {
+    const body = {
+      data: {
+        relationships: {
+          'document-container': {
+            data: {
+              id: this.model.documentContainer.id,
+            },
+          },
+          'snippet-list': {
+            data: {
+              id: this.model.snippetList.id,
+            },
+          },
+        },
+      },
+    };
 
-    const publicationTask = this.store.createRecord(
-      'snippet-list-publication-task',
+    const taskId = await this.muTask.fetchTaskifiedEndpoint(
+      '/snippet-list-publication-tasks',
+      {
+        method: 'POST',
+        body: JSON.stringify(body),
+        headers: {
+          'Content-Type': 'application/vnd.api+json',
+        },
+      },
     );
 
-    publicationTask.documentContainer = documentContainer;
-    publicationTask.snippetList = snippetList;
-    await publicationTask.save();
-
-    await this.muTask.waitForMuTaskTask.perform(publicationTask.id, 100);
+    await this.muTask.waitForMuTaskTask.perform(taskId, 100);
   });
 }

--- a/app/models/regulatory-attachment-publication-task.js
+++ b/app/models/regulatory-attachment-publication-task.js
@@ -1,7 +1,0 @@
-import Model, { attr, belongsTo } from '@ember-data/model';
-
-export default class RegulatoryAttachmentPublicationTask extends Model {
-  @belongsTo('document-container', { async: true, inverse: null })
-  documentContainer;
-  @attr status;
-}

--- a/app/models/snippet-list-publication-task.js
+++ b/app/models/snippet-list-publication-task.js
@@ -1,9 +1,0 @@
-import Model, { attr, belongsTo } from '@ember-data/model';
-
-export default class SnippetListPublicationTask extends Model {
-  @belongsTo('document-container', { async: true, inverse: null })
-  documentContainer;
-  @belongsTo('snippet-list', { async: true, inverse: null })
-  snippetList;
-  @attr status;
-}

--- a/app/templates/snippets-management/edit/edit-snippet.hbs
+++ b/app/templates/snippets-management/edit/edit-snippet.hbs
@@ -7,7 +7,7 @@
   @documentContainer={{this.model.documentContainer}}
   @save={{hash action=(perform this.save) isRunning=this.save.isRunning}}
   @dirty={{this.dirty}}
-  @onUpdateDocumentTitle={{perform this.updateDocumentTitle}}
+  @onUpdateDocumentTitle={{perform this.publishSnippet}}
 />
 {{#if this.editorDocument}}
   <RdfaEditorContainer


### PR DESCRIPTION
## Overview
This PR removes the `snippet-list-publication-task` and `regulatory-attachment-publication-task` models and replaces them by simple fetch requests. 
This is done for two reasons:
- Ember Data is not really leveraged for these tasks, they only are posted using ember-data, not fetched.
- The content/structure of a task is not really consistent. The request body is not equal to the format of the response body of a task, so it does not following JSON:API correctly.

### How to test/reproduce
The functionality of this app should remain the same. The requests made to the backend remain the same

### Challenges/uncertainties
I understand moving away from ED for these tasks is an opinionated change, maybe it is deemed better to keep using ED for the tasks. In that case we should ensure that the backend (the reglement-publish-service) follows the JSON:API spec consistently. We should then probably also use ED consistently to fetch/post the task, and not only partially.



### Checks PR readiness
- [x] UI: works on smaller screen sizes
- [x] UI: feedback for any loading/error states
- [x] Check cancel/go-back flows
- [x] Check database state correct when deleting/updating (especially regarding relationships)
- [x] changelog
- [x] npm lint
- [x] no new deprecations