### PR TITLE
Use `/tasks/:id` endpoint to fetch information/status of a task.

### DIFF
--- a/.changeset/five-students-collect.md
+++ b/.changeset/five-students-collect.md
@@ -1,0 +1,5 @@
+---
+"frontend-reglementaire-bijlage": patch
+---
+
+When fetching task information, use `/tasks/:id` endpoint instead of `/regulatory-attachment-publication-tasks/:id` endpoint

--- a/app/services/mu-task.js
+++ b/app/services/mu-task.js
@@ -1,7 +1,7 @@
 import Service from '@ember/service';
 import { task, timeout } from 'ember-concurrency';
 
-const TASK_ENDPOINT = '/regulatory-attachment-publication-tasks';
+const TASK_ENDPOINT = '/tasks';
 export const TASK_STATUS_FAILURE =
   'http://lblod.data.gift/besluit-publicatie-melding-statuses/failure';
 export const TASK_STATUS_CREATED =


### PR DESCRIPTION
Visit https://github.com/lblod/app-reglementaire-bijlage/pull/78 for a summary of the changes included in this PR.