### PR TITLE
Update `@lblod/ember-rdfa-editor` to 9.7.0 and enable support for hierarchical lists

### DIFF
--- a/.changeset/sweet-bees-enjoy.md
+++ b/.changeset/sweet-bees-enjoy.md
@@ -1,0 +1,5 @@
+---
+"frontend-reglementaire-bijlage": patch
+---
+
+Update `@lblod/ember-rdfa-editor` to version 9.7.0

--- a/.changeset/swift-falcons-pump.md
+++ b/.changeset/swift-falcons-pump.md
@@ -1,0 +1,5 @@
+---
+"frontend-reglementaire-bijlage": minor
+---
+
+Enable support for hierarchical lists

--- a/app/controllers/regulatory-attachments/edit.js
+++ b/app/controllers/regulatory-attachments/edit.js
@@ -36,9 +36,10 @@ import {
   STRUCTURE_SPECS,
 } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/article-structure-plugin/structures';
 import {
-  bullet_list,
-  list_item,
-  ordered_list,
+  bulletListWithConfig,
+  listItemWithConfig,
+  listTrackingPlugin,
+  orderedListWithConfig,
 } from '@lblod/ember-rdfa-editor/plugins/list';
 import { placeholder } from '@lblod/ember-rdfa-editor/plugins/placeholder';
 import { heading } from '@lblod/ember-rdfa-editor/plugins/heading';
@@ -102,9 +103,9 @@ export default class EditController extends Controller {
       document_title,
       repaired_block,
 
-      list_item,
-      ordered_list,
-      bullet_list,
+      list_item: listItemWithConfig({ enableHierarchicalList: true }),
+      ordered_list: orderedListWithConfig({ enableHierarchicalList: true }),
+      bullet_list: bulletListWithConfig({ enableHierarchicalList: true }),
       templateComment,
       placeholder,
       ...tableNodes({ tableGroup: 'block', cellContent: 'block+' }),
@@ -243,6 +244,7 @@ export default class EditController extends Controller {
       tableKeymap,
       this.citationPlugin,
       linkPasteHandler(this.schema.nodes.link),
+      listTrackingPlugin(),
     ];
   }
 

--- a/app/controllers/snippets-management/edit/edit-snippet.js
+++ b/app/controllers/snippets-management/edit/edit-snippet.js
@@ -36,9 +36,10 @@ import {
   STRUCTURE_SPECS,
 } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/article-structure-plugin/structures';
 import {
-  bullet_list,
-  list_item,
-  ordered_list,
+  bulletListWithConfig,
+  listItemWithConfig,
+  listTrackingPlugin,
+  orderedListWithConfig,
 } from '@lblod/ember-rdfa-editor/plugins/list';
 import { placeholder } from '@lblod/ember-rdfa-editor/plugins/placeholder';
 import { heading } from '@lblod/ember-rdfa-editor/plugins/heading';
@@ -99,9 +100,9 @@ export default class SnippetsManagementEditSnippetController extends Controller 
       document_title,
       repaired_block,
 
-      list_item,
-      ordered_list,
-      bullet_list,
+      list_item: listItemWithConfig({ enableHierarchicalList: true }),
+      ordered_list: orderedListWithConfig({ enableHierarchicalList: true }),
+      bullet_list: bulletListWithConfig({ enableHierarchicalList: true }),
       templateComment,
       placeholder,
       ...tableNodes({ tableGroup: 'block', cellContent: 'block+' }),
@@ -236,6 +237,7 @@ export default class SnippetsManagementEditSnippetController extends Controller 
       tableKeymap,
       this.citationPlugin,
       linkPasteHandler(this.schema.nodes.link),
+      listTrackingPlugin(),
     ];
   }
 

--- a/app/templates/regulatory-attachments/edit.hbs
+++ b/app/templates/regulatory-attachments/edit.hbs
@@ -66,7 +66,7 @@
           </Tb.Group>
           <Tb.Group>
             <Plugins::List::Unordered @controller={{this.editor}} />
-            <Plugins::List::Ordered @controller={{this.editor}} />
+            <Plugins::List::Ordered @controller={{this.editor}} @enableHierarchicalList={{true}}/>
             <Plugins::Indentation::IndentationMenu
               @controller={{this.editor}}
             />

--- a/app/templates/snippets-management/edit/edit-snippet.hbs
+++ b/app/templates/snippets-management/edit/edit-snippet.hbs
@@ -46,7 +46,7 @@
           </Tb.Group>
           <Tb.Group>
             <Plugins::List::Unordered @controller={{this.editor}} />
-            <Plugins::List::Ordered @controller={{this.editor}} />
+            <Plugins::List::Ordered @controller={{this.editor}} @enableHierarchicalList={{true}}/>
             <Plugins::Indentation::IndentationMenu
               @controller={{this.editor}}
             />

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,7 +32,7 @@
         "@lblod/ember-acmidm-login": "^2.0.0-beta.1",
         "@lblod/ember-environment-banner": "^0.5.0",
         "@lblod/ember-mock-login": "^0.7.0",
-        "@lblod/ember-rdfa-editor": "^9.6.0",
+        "@lblod/ember-rdfa-editor": "^9.7.0",
         "@lblod/ember-rdfa-editor-lblod-plugins": "^17.0.0",
         "@release-it-plugins/lerna-changelog": "^6.0.0",
         "broccoli-asset-rev": "^3.0.0",
@@ -4697,9 +4697,9 @@
       }
     },
     "node_modules/@lblod/ember-rdfa-editor": {
-      "version": "9.6.0",
-      "resolved": "https://registry.npmjs.org/@lblod/ember-rdfa-editor/-/ember-rdfa-editor-9.6.0.tgz",
-      "integrity": "sha512-cp9eK/C1xzWh/JVwEijQr6EmOkKysiu08WRhnXFWa4nWv7Zb0rf67MDlL1GD149I7Dtid8NAESwDng9latN1VQ==",
+      "version": "9.7.0",
+      "resolved": "https://registry.npmjs.org/@lblod/ember-rdfa-editor/-/ember-rdfa-editor-9.7.0.tgz",
+      "integrity": "sha512-bMmC0sL5NuIg5R7V2fCGJQDioggIpudNE26gow1uJ02AjtFWSREDmPByLMUhAndPswudwR+2wbA+Nejt6teypg==",
       "dev": true,
       "dependencies": {
         "@babel/core": "^7.23.7",
@@ -4717,7 +4717,7 @@
         "@graphy/memory.dataset.fast": "4.3.3",
         "@lblod/marawa": "^0.8.0-beta.2",
         "@say-editor/prosemirror-invisibles": "^0.1.0",
-        "@say-editor/prosemirror-tables": "^0.2.0",
+        "@say-editor/prosemirror-tables": "^0.3.0",
         "codemirror": "^6.0.1",
         "common-tags": "^1.8.0",
         "crypto-browserify": "^3.12.0",
@@ -6283,9 +6283,9 @@
       }
     },
     "node_modules/@say-editor/prosemirror-tables": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@say-editor/prosemirror-tables/-/prosemirror-tables-0.2.0.tgz",
-      "integrity": "sha512-dkbJQhAO6TpurDW+LNek4yCZBsAY0KpXJLtSeibSkWYNQ/PFHgbjyNXsmd6kCuv637qqDu+kY+vm6wZhpIJaTw==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@say-editor/prosemirror-tables/-/prosemirror-tables-0.3.0.tgz",
+      "integrity": "sha512-V8Y4I46exOpq9MRAwPOB6iYvBrKr/xTGUmkSDqo3MenFt3C8RbE4QMmsEOFhEHD28ezI14l4urMIVgckCw/hGA==",
       "dev": true,
       "dependencies": {
         "prosemirror-keymap": "^1.1.2",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "@lblod/ember-acmidm-login": "^2.0.0-beta.1",
     "@lblod/ember-environment-banner": "^0.5.0",
     "@lblod/ember-mock-login": "^0.7.0",
-    "@lblod/ember-rdfa-editor": "^9.6.0",
+    "@lblod/ember-rdfa-editor": "^9.7.0",
     "@lblod/ember-rdfa-editor-lblod-plugins": "^17.0.0",
     "@release-it-plugins/lerna-changelog": "^6.0.0",
     "broccoli-asset-rev": "^3.0.0",


### PR DESCRIPTION
### Overview
This PR includes two changes:
- Update of `@lblod/ember-rdfa-editor` to 9.7.0
- Support for hierarchical lists
