### PR TITLE
Fix publication date of RB not being updated

### DIFF
--- a/.changeset/metal-badgers-judge.md
+++ b/.changeset/metal-badgers-judge.md
@@ -1,0 +1,5 @@
+---
+"frontend-reglementaire-bijlage": patch
+---
+
+Fixed wrong published version date being shown

--- a/app/controllers/regulatory-attachments/publish.js
+++ b/app/controllers/regulatory-attachments/publish.js
@@ -53,6 +53,7 @@ export default class PublishController extends Controller {
         },
       },
     );
+    console.log(taskId);
     await this.muTask.waitForMuTaskTask.perform(taskId, 100);
     await this.fetchPreview.perform();
     this.toaster.success(

--- a/app/controllers/regulatory-attachments/publish.js
+++ b/app/controllers/regulatory-attachments/publish.js
@@ -53,7 +53,6 @@ export default class PublishController extends Controller {
         },
       },
     );
-    console.log(taskId);
     await this.muTask.waitForMuTaskTask.perform(taskId, 100);
     await this.fetchPreview.perform();
     this.toaster.success(

--- a/app/routes/regulatory-attachments/index.js
+++ b/app/routes/regulatory-attachments/index.js
@@ -30,7 +30,7 @@ export default class ListRoute extends Route {
         number: params.page,
         size: params.size,
       },
-      include: 'published-version.current-version'
+      include: 'published-version.current-version',
     };
 
     if (params.title) {

--- a/app/routes/regulatory-attachments/index.js
+++ b/app/routes/regulatory-attachments/index.js
@@ -25,6 +25,7 @@ export default class ListRoute extends Route {
           id: RS_STANDARD_FOLDER,
         },
       },
+      avoid_cache_param: new Date().toISOString(), //Adding this param so the query skippes the cache and grabs the latest published date of each RB
       sort: params.sort,
       page: {
         number: params.page,

--- a/app/routes/regulatory-attachments/index.js
+++ b/app/routes/regulatory-attachments/index.js
@@ -30,12 +30,12 @@ export default class ListRoute extends Route {
         number: params.page,
         size: params.size,
       },
+      include: 'published-version.current-version'
     };
 
     if (params.title) {
       options['filter[current-version][title]'] = params.title;
     }
-
     return await this.store.query('document-container', options);
   }
 

--- a/app/routes/regulatory-attachments/index.js
+++ b/app/routes/regulatory-attachments/index.js
@@ -32,6 +32,8 @@ export default class ListRoute extends Route {
         size: params.size,
       },
       include: 'published-version.current-version',
+      /* This include should not be removed as when we publish a new RB ember data doesn't know about the update, 
+      with this include and the cache param we force it to update */
     };
 
     if (params.title) {

--- a/app/services/mu-task.js
+++ b/app/services/mu-task.js
@@ -48,7 +48,6 @@ export default class MuTaskService extends Service {
         const reason = await resp.text();
         throw new Error(reason);
       }
-      console.log(currentStatus);
       if (currentStatus === TASK_STATUS_SUCCESS) {
         return jsonBody;
       } else if (currentStatus === TASK_STATUS_FAILURE) {

--- a/app/services/mu-task.js
+++ b/app/services/mu-task.js
@@ -48,7 +48,7 @@ export default class MuTaskService extends Service {
         const reason = await resp.text();
         throw new Error(reason);
       }
-
+      console.log(currentStatus);
       if (currentStatus === TASK_STATUS_SUCCESS) {
         return jsonBody;
       } else if (currentStatus === TASK_STATUS_FAILURE) {


### PR DESCRIPTION
## Overview
Included published version on RB query because it was caching it in the production mode, resulting in wrong information being shown

##### connected issues and PRs:
GN-4575


### Setup
You will need to use a built version of the frontend in order to reproduce, because it worked perfeclty fine on dev

### How to test/reproduce
Go to RB, create a new one, publish it and go back to the index, the published date should be correct

### Challenges/uncertainties
None



### Checks PR readiness
- [x] UI: works on smaller screen sizes
- [x] UI: feedback for any loading/error states
- [x] Check cancel/go-back flows
- [x] Check database state correct when deleting/updating (especially regarding relationships)
- [x] changelog
- [x] npm lint
- [x] no new deprecations