### PR TITLE
Made possible to override the confirm modal

### DIFF
--- a/.changeset/lucky-ways-glow.md
+++ b/.changeset/lucky-ways-glow.md
@@ -1,0 +1,5 @@
+---
+"frontend-reglementaire-bijlage": patch
+---
+
+Fix save and publish first saves then goes to publish

--- a/app/components/confirm-route-leave.js
+++ b/app/components/confirm-route-leave.js
@@ -52,7 +52,7 @@ export default class ConfirmRouteLeaveComponent extends Component {
   }
 
   abortTransition(transition) {
-    if(transition?.to?.queryParams?.overrideConfirm) {
+    if (transition.to.queryParams?.overrideConfirm) {
       return;
     }
     transition.abort();

--- a/app/components/confirm-route-leave.js
+++ b/app/components/confirm-route-leave.js
@@ -52,6 +52,9 @@ export default class ConfirmRouteLeaveComponent extends Component {
   }
 
   abortTransition(transition) {
+    if(transition?.to?.queryParams?.overrideConfirm) {
+      return;
+    }
     transition.abort();
     if (window.history) {
       window.history.forward();

--- a/app/controllers/regulatory-attachments/edit.js
+++ b/app/controllers/regulatory-attachments/edit.js
@@ -325,6 +325,9 @@ export default class EditController extends Controller {
     this.router.transitionTo(
       'regulatory-attachments.publish',
       this.model.documentContainer.id,
+      {queryParams: {
+        overrideConfirm: true
+      }}
     );
   });
 

--- a/app/controllers/regulatory-attachments/edit.js
+++ b/app/controllers/regulatory-attachments/edit.js
@@ -325,9 +325,11 @@ export default class EditController extends Controller {
     this.router.transitionTo(
       'regulatory-attachments.publish',
       this.model.documentContainer.id,
-      {queryParams: {
-        overrideConfirm: true
-      }}
+      {
+        queryParams: {
+          overrideConfirm: true,
+        },
+      },
     );
   });
 


### PR DESCRIPTION
## Overview
So basically the problem is that when you save for the first time a race condition makes that the editor is flagged as dirty. So the confirm modal cancels the transition.
My proposed solution is to add these queryParams in order to override the confirm modal when we know the document has just been saved. May not be the best solution so please comment on it if you have a better one

##### connected issues and PRs:
GN-4687


### Setup
This only happens on production build, so you will need to build a docker image for it
### How to test/reproduce
create a new regulatory statement, modify it, and then click on save and publish



### Checks PR readiness
- [x] UI: works on smaller screen sizes
- [x] UI: feedback for any loading/error states
- [x] Check cancel/go-back flows
- [x] Check database state correct when deleting/updating (especially regarding relationships)
- [x] changelog
- [x] npm lint
- [x] no new deprecations