### PR TITLE
Correctly tag release builds as latest in docker hub

### DIFF
--- a/.changeset/purple-ducks-buy.md
+++ b/.changeset/purple-ducks-buy.md
@@ -1,0 +1,5 @@
+---
+"frontend-reglementaire-bijlage": patch
+---
+
+Correctly tag release builds as latest

--- a/.woodpecker/.release.yml
+++ b/.woodpecker/.release.yml
@@ -3,7 +3,7 @@ pipeline:
     image: plugins/docker
     settings:
       repo: "${CI_REPO_OWNER}/${CI_REPO_NAME}"
-      tags: "${CI_COMMIT_TAG##v}"
+      tags: [ "latest", "${CI_COMMIT_TAG##v}" ]
     secrets: [ docker_username, docker_password ]
 when:
   event: tag


### PR DESCRIPTION
## Overview
The release woodpecker build is only pushing to the specific version tag, not to `:latest`, so `:latest` is actually pushed from the latest script. Woodpecker doesn't seem to run latest for the release commit, presumably either because it triggers the release pipeline, or because it's pushed at the same time, so there's only one 'push' event (not sure why it wouldn't pick the latest pushed commit though).
So until the first change to master after a release, `:latest` will always misreport as being the previous version.

##### connected issues and PRs:
<!-- links to connected jira tickets -->
<!-- Link to PRs that are related (and in what way) -->

##### connected issues and PRs:
N/A

### Setup
N/A

### How to test/reproduce
Push a new tag and verify in docker hub that the shas for both that version and `latest` are the same.

### Challenges/uncertainties
I don't know for sure if this will work, their docs don't say how to specify multiple tags, but their code looks like just comma seperating works.

### Checks PR readiness
- [ ] UI: works on smaller screen sizes
- [ ] UI: feedback for any loading/error states
- [ ] Check cancel/go-back flows
- [ ] Check database state correct when deleting/updating (especially regarding relationships)
- [ ] changelog
- [ ] npm lint
- [ ] no new deprecations