### PR TITLE
GN-4957: add `no-case` modifier where necessary

### DIFF
--- a/.changeset/three-vans-tie.md
+++ b/.changeset/three-vans-tie.md
@@ -1,0 +1,5 @@
+---
+"frontend-reglementaire-bijlage": patch
+---
+
+Add `no-case` modifier to sorted string fields

--- a/app/templates/codelist-management/index.hbs
+++ b/app/templates/codelist-management/index.hbs
@@ -40,7 +40,7 @@
   <s.content as |c|>
     <c.header>
       <AuDataTableThSortable
-        @field="label"
+        @field=":no-case:label"
         @currentSorting={{this.sort}}
         @label={{t "codelist.attr.label"}}
       />

--- a/app/templates/snippet-management/index.hbs
+++ b/app/templates/snippet-management/index.hbs
@@ -41,7 +41,7 @@
     <s.content as |c|>
       <c.header>
         <AuDataTableThSortable
-          @field="label"
+          @field=":no-case:label"
           @currentSorting={{this.sort}}
           @label={{t "snippets.attr.label"}}
         />

--- a/app/templates/template-management/index.hbs
+++ b/app/templates/template-management/index.hbs
@@ -43,7 +43,7 @@
   <table.content as |c|>
     <c.header>
       <AuDataTableThSortable
-        @field="currentVersion.title"
+        @field=":no-case:currentVersion.title"
         @currentSorting={{this.sort}}
         @label={{t "template-management.title"}}
       />


### PR DESCRIPTION
## Overview
This PR adds a `no-case` modifier to sortable string fields (relevant in the snippet, template and codelist overviews). This ensures that sorting on title/label alphabetically works as expected.

##### connected issues and PRs:
[GN-4957](https://binnenland.atlassian.net/browse/GN-4957)

### How to test/reproduce
- Start the app
- Open up one of the overview pages (snippets/templates/codelists)
- Ensure sorting on title/label works as expected

### Challenges/uncertainties
The `no-case` modifier is required for both case-insensitive sorting and for string sorting to work. (string sorting does not work in combination with `MAX` in sparql queries due to a bug in virtuoso).

### Checks PR readiness
- [x] UI: works on smaller screen sizes
- [x] UI: feedback for any loading/error states
- [x] Check cancel/go-back flows
- [x] Check database state correct when deleting/updating (especially regarding relationships)
- [x] changelog
- [x] npm lint
- [x] no new deprecations