### PR TITLE
GN-4976: disable fingerprinting on ember-leaflet assets

### DIFF
--- a/.changeset/nice-avocados-study.md
+++ b/.changeset/nice-avocados-study.md
@@ -1,0 +1,5 @@
+---
+'frontend-gelinkt-notuleren': patch
+---
+
+Exlude ember-leaflet assets from fingerprinting

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -8,6 +8,15 @@ module.exports = function (defaults) {
       extension: 'scss',
       includePaths: ['node_modules/@appuniversum/ember-appuniversum'],
     },
+    fingerprint: {
+      exclude: [
+        'images/layers-2x.png',
+        'images/layers.png',
+        'images/marker-icon-2x.png',
+        'images/marker-icon.png',
+        'images/marker-shadow.png',
+      ],
+    },
   });
 
   // Use `app.import` to add additional libraries to the generated


### PR DESCRIPTION
### Overview
This PR excludes ember-leaflet assets from fingerprinting

##### connected issues and PRs:
[GN-4976](https://binnenland.atlassian.net/browse/GN-4976?atlOrigin=eyJpIjoiMTM5ZjEzZmUzZWFmNDZjYWI3ZTJmZWI5OWI1MmJhN2YiLCJwIjoiaiJ9)
Check-out https://github.com/lblod/ember-rdfa-editor-lblod-plugins/pull/464 for more information.
