### PR TITLE
Support decision articles in snippets

### DIFF
--- a/.changeset/green-roses-pretend.md
+++ b/.changeset/green-roses-pretend.md
@@ -1,0 +1,10 @@
+---
+"frontend-reglementaire-bijlage": minor
+---
+
+Restructure snippet editor sidebar intro 3 sections:
+- Algemene nodes (General nodes): contains actions such as inserting dates, citations etc.
+- Besluit nodes (Decision nodes): contains actions such as inserting a mandatee table, decision article
+- Reglementaire Bijlage nodes (Regulatory statement nodes): contains actions such as inserting article structures, document titles
+
+This division should make it easier for the creator of the template to use the editor

--- a/.changeset/slimy-mangos-drive.md
+++ b/.changeset/slimy-mangos-drive.md
@@ -1,0 +1,5 @@
+---
+"frontend-reglementaire-bijlage": minor
+---
+
+Add support for decision articles to snippets

--- a/app/controllers/snippet-management/edit/edit-snippet.js
+++ b/app/controllers/snippet-management/edit/edit-snippet.js
@@ -93,6 +93,14 @@ import {
 import AttributeEditor from '@lblod/ember-rdfa-editor/components/_private/attribute-editor';
 import RdfaEditor from '@lblod/ember-rdfa-editor/components/_private/rdfa-editor';
 import DebugInfo from '@lblod/ember-rdfa-editor/components/_private/debug-info';
+
+import InsertArticleComponent from '@lblod/ember-rdfa-editor-lblod-plugins/components/decision-plugin/insert-article';
+import StructureControlCardComponent from '@lblod/ember-rdfa-editor-lblod-plugins/components/structure-plugin/_private/control-card';
+import {
+  structure,
+  structureView,
+} from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/structure-plugin/node';
+
 import {
   osloLocation,
   osloLocationView,
@@ -101,11 +109,12 @@ import {
   mandatee_table,
   mandateeTableView,
 } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/mandatee-table-plugin/node';
-
 export default class SnippetManagementEditSnippetController extends Controller {
   AttributeEditor = AttributeEditor;
   RdfaEditor = RdfaEditor;
   DebugInfo = DebugInfo;
+  InsertArticle = InsertArticleComponent;
+  StructureControlCard = StructureControlCardComponent;
 
   @service store;
   @service router;
@@ -124,6 +133,7 @@ export default class SnippetManagementEditSnippetController extends Controller {
         rdfaAware: true,
       }),
       paragraph,
+      structure,
       document_title,
       repaired_block: repairedBlockWithConfig({ rdfaAware: true }),
 
@@ -290,6 +300,7 @@ export default class SnippetManagementEditSnippetController extends Controller {
         person_variable: personVariableView(controller),
         inline_rdfa: inlineRdfaWithConfigView({ rdfaAware: true })(controller),
         oslo_location: osloLocationView(this.config.location)(controller),
+        structure: structureView(controller),
         mandatee_table: mandateeTableView(controller),
       };
     };

--- a/app/templates/snippet-management/edit/edit-snippet.hbs
+++ b/app/templates/snippet-management/edit/edit-snippet.hbs
@@ -86,18 +86,9 @@
       {{#if this.editor}}
         <Sidebar as |Sidebar|>
           <Sidebar.Collapsible
-            @title={{t "utility.insert"}}
-            @expandedInitially={{true}}
+            @title={{t 'snippet-edit.sidebar.general-nodes'}}
+            @expandedInitially={{false}}
           >
-            <this.InsertArticle
-              @controller={{this.editor}}
-              @options={{hash insertFreely=true}}
-            />
-            <DocumentTitlePlugin::InsertTitleCard @controller={{this.editor}} />
-            <ArticleStructurePlugin::ArticleStructureCard
-              @controller={{this.editor}}
-              @options={{this.config.structures}}
-            />
             <VariablePlugin::Date::Insert
               @controller={{this.editor}}
               @options={{this.config.date}}
@@ -107,16 +98,33 @@
               @plugin={{this.citationPlugin}}
               @config={{this.config.citation}}
             />
-
             <LocationPlugin::Insert
               @controller={{this.editor}}
               @config={{this.config.location}}
             />
             <TemplateCommentsPlugin::Insert @controller={{this.editor}} />
             <VariablePlugin::Address::Insert @controller={{this.editor}} />
+          </Sidebar.Collapsible>
+          <Sidebar.Collapsible
+            @title={{t 'snippet-edit.sidebar.decision-nodes'}}
+            @expandedInitially={{false}}
+          >
+            <this.InsertArticle
+              @controller={{this.editor}}
+              @options={{hash insertFreely=true}}
+            />
             <MandateeTablePlugin::Insert
               @controller={{this.editor}}
               @defaultTag={{this.config.mandateeTable.defaultTag}}
+            />
+          </Sidebar.Collapsible>
+          <Sidebar.Collapsible
+            @title={{t 'snippet-edit.sidebar.regulatory-statement-nodes'}}
+            @expandedInitially={{false}}>
+            <DocumentTitlePlugin::InsertTitleCard @controller={{this.editor}} />
+            <ArticleStructurePlugin::ArticleStructureCard
+              @controller={{this.editor}}
+              @options={{this.config.structures}}
             />
           </Sidebar.Collapsible>
           <this.StructureControlCard @controller={{this.editor}} />

--- a/app/templates/snippet-management/edit/edit-snippet.hbs
+++ b/app/templates/snippet-management/edit/edit-snippet.hbs
@@ -89,6 +89,10 @@
             @title={{t "utility.insert"}}
             @expandedInitially={{true}}
           >
+            <this.InsertArticle
+              @controller={{this.editor}}
+              @options={{hash insertFreely=true}}
+            />
             <DocumentTitlePlugin::InsertTitleCard @controller={{this.editor}} />
             <ArticleStructurePlugin::ArticleStructureCard
               @controller={{this.editor}}
@@ -115,6 +119,7 @@
               @defaultTag={{this.config.mandateeTable.defaultTag}}
             />
           </Sidebar.Collapsible>
+          <this.StructureControlCard @controller={{this.editor}} />
           <MandateeTablePlugin::Configure
             @controller={{this.editor}}
             @supportedTags={{this.config.mandateeTable.tags}}

--- a/app/templates/template-management/edit.hbs
+++ b/app/templates/template-management/edit.hbs
@@ -118,31 +118,15 @@
     <:aside>
       {{#if this.editor}}
         <Sidebar as |Sidebar|>
+
           <Sidebar.Collapsible
-            @title={{t "utility.insert"}}
-            @expandedInitially={{true}}
+            @title={{t 'snippet-edit.sidebar.general-nodes'}}
+            @expandedInitially={{false}}
           >
-            <this.StructureInsert @controller={{this.editor}} />
-            {{#if (eq this.internalTypeName "decision")}}
-              <RoadsignRegulationPlugin::RoadsignRegulationCard
-                @controller={{this.editor}}
-                @options={{this.config.roadsignRegulation}}
-              />
-            {{/if}}
-            {{#unless (eq this.internalTypeName "decision")}}
-              <DocumentTitlePlugin::InsertTitleCard
-                @controller={{this.editor}}
-              />
-            {{/unless}}
-            <ArticleStructurePlugin::ArticleStructureCard
-              @controller={{this.editor}}
-              @options={{this.config.structures}}
-            />
             <VariablePlugin::Date::Insert
               @controller={{this.editor}}
               @options={{this.config.date}}
             />
-
             <LocationPlugin::Insert
               @controller={{this.editor}}
               @config={{this.config.location}}
@@ -152,27 +136,47 @@
               @plugin={{this.citationPlugin}}
               @config={{this.config.citation}}
             />
-            <SnippetPlugin::SnippetInsertPlaceholder
-              @controller={{this.editor}}
-              @config={{this.config.snippet}}
-            />
             {{#if this.supportsComments}}
               <TemplateCommentsPlugin::Insert @controller={{this.editor}} />
             {{/if}}
             <VariablePlugin::Address::Insert @controller={{this.editor}} />
-
-            {{#if (eq this.internalTypeName "decision")}}
+            <SnippetPlugin::SnippetInsertPlaceholder
+              @controller={{this.editor}}
+              @config={{this.config.snippet}}
+            />
+          </Sidebar.Collapsible>
+          {{#if (eq this.internalTypeName "decision")}}
+            <Sidebar.Collapsible
+              @title={{t 'snippet-edit.sidebar.decision-nodes'}}
+              @expandedInitially={{false}}
+            >
+              <this.StructureInsert @controller={{this.editor}} />
               <MandateeTablePlugin::Insert
                 @controller={{this.editor}}
                 @defaultTag={{this.config.mandateeTable.defaultTag}}
               />
-            {{/if}}
-          </Sidebar.Collapsible>
-          {{#if (eq this.internalTypeName "decision")}}
-            <DecisionPlugin::DecisionPluginCard @controller={{this.editor}} />
-            <this.StructureControl @controller={{this.editor}} />
+              <RoadsignRegulationPlugin::RoadsignRegulationCard
+                @controller={{this.editor}}
+                @options={{this.config.roadsignRegulation}}
+              />
+              <DecisionPlugin::DecisionPluginCard @controller={{this.editor}} />
 
+            </Sidebar.Collapsible>
           {{/if}}
+
+          {{#unless (eq this.internalTypeName "decision")}}
+            <Sidebar.Collapsible
+              @title={{t 'snippet-edit.sidebar.regulatory-statement-nodes'}}
+              @expandedInitially={{false}}>
+                <DocumentTitlePlugin::InsertTitleCard
+                  @controller={{this.editor}}
+                />
+                <ArticleStructurePlugin::ArticleStructureCard
+                  @controller={{this.editor}}
+                  @options={{this.config.structures}}
+                />
+            </Sidebar.Collapsible>
+          {{/unless}}
           <Plugins::Link::LinkEditor @controller={{this.editor}} />
           <this.RdfaEditor
             @node={{this.activeNode}}
@@ -185,6 +189,7 @@
             />
             <this.DebugInfo @node={{this.activeNode}} />
           {{/if}}
+          <this.StructureControl @controller={{this.editor}} />
           <MandateeTablePlugin::Configure
             @controller={{this.editor}}
             @supportedTags={{this.config.mandateeTable.tags}}

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,7 @@
         "@lblod/ember-environment-banner": "^0.5.0",
         "@lblod/ember-mock-login": "^0.10.0",
         "@lblod/ember-rdfa-editor": "^10.0.3",
-        "@lblod/ember-rdfa-editor-lblod-plugins": "22.3.0",
+        "@lblod/ember-rdfa-editor-lblod-plugins": "22.3.0-dev.c89efc976b1b97b342236a6e3873d4fa770c80e6",
         "@release-it-plugins/lerna-changelog": "^6.0.0",
         "broccoli-asset-rev": "^3.0.0",
         "changesets-release-it-plugin": "^0.1.2",
@@ -5123,9 +5123,9 @@
       }
     },
     "node_modules/@lblod/ember-rdfa-editor-lblod-plugins": {
-      "version": "22.3.0",
-      "resolved": "https://registry.npmjs.org/@lblod/ember-rdfa-editor-lblod-plugins/-/ember-rdfa-editor-lblod-plugins-22.3.0.tgz",
-      "integrity": "sha512-SsRxwHxsKivNmZGbAmF3+VRiab9bdsrepWsgGC3vVHSktiYMItgJOJs1ia5d3mviMvLD8DCqf5+iCspJBfi1JA==",
+      "version": "22.3.0-dev.c89efc976b1b97b342236a6e3873d4fa770c80e6",
+      "resolved": "https://registry.npmjs.org/@lblod/ember-rdfa-editor-lblod-plugins/-/ember-rdfa-editor-lblod-plugins-22.3.0-dev.c89efc976b1b97b342236a6e3873d4fa770c80e6.tgz",
+      "integrity": "sha512-Bfz4egO45VJDzYpzmC5lmtXwfPnHSVD1SV+c4LifJobZPMUEJ9uOetpIrMDiOxRR4EfkhRy9deDF4uZFMhktTQ==",
       "dev": true,
       "dependencies": {
         "@codemirror/lang-html": "^6.4.9",

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,7 @@
         "@lblod/ember-environment-banner": "^0.5.0",
         "@lblod/ember-mock-login": "^0.10.0",
         "@lblod/ember-rdfa-editor": "^10.0.3",
-        "@lblod/ember-rdfa-editor-lblod-plugins": "22.3.0-dev.c89efc976b1b97b342236a6e3873d4fa770c80e6",
+        "@lblod/ember-rdfa-editor-lblod-plugins": "22.4.0",
         "@release-it-plugins/lerna-changelog": "^6.0.0",
         "broccoli-asset-rev": "^3.0.0",
         "changesets-release-it-plugin": "^0.1.2",
@@ -5123,9 +5123,9 @@
       }
     },
     "node_modules/@lblod/ember-rdfa-editor-lblod-plugins": {
-      "version": "22.3.0-dev.c89efc976b1b97b342236a6e3873d4fa770c80e6",
-      "resolved": "https://registry.npmjs.org/@lblod/ember-rdfa-editor-lblod-plugins/-/ember-rdfa-editor-lblod-plugins-22.3.0-dev.c89efc976b1b97b342236a6e3873d4fa770c80e6.tgz",
-      "integrity": "sha512-Bfz4egO45VJDzYpzmC5lmtXwfPnHSVD1SV+c4LifJobZPMUEJ9uOetpIrMDiOxRR4EfkhRy9deDF4uZFMhktTQ==",
+      "version": "22.4.0",
+      "resolved": "https://registry.npmjs.org/@lblod/ember-rdfa-editor-lblod-plugins/-/ember-rdfa-editor-lblod-plugins-22.4.0.tgz",
+      "integrity": "sha512-HEA31h0o7VdZQYn5a2gazpXxDuVRXHXCBhu4G/g2M0PPTjIrYRmnDuTF7ViE8IqRehJqP4A25Caf7UvoNw1qlw==",
       "dev": true,
       "dependencies": {
         "@codemirror/lang-html": "^6.4.9",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "@lblod/ember-environment-banner": "^0.5.0",
     "@lblod/ember-mock-login": "^0.10.0",
     "@lblod/ember-rdfa-editor": "^10.0.3",
-    "@lblod/ember-rdfa-editor-lblod-plugins": "22.3.0",
+    "@lblod/ember-rdfa-editor-lblod-plugins": "22.3.0-dev.c89efc976b1b97b342236a6e3873d4fa770c80e6",
     "@release-it-plugins/lerna-changelog": "^6.0.0",
     "broccoli-asset-rev": "^3.0.0",
     "changesets-release-it-plugin": "^0.1.2",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "@lblod/ember-environment-banner": "^0.5.0",
     "@lblod/ember-mock-login": "^0.10.0",
     "@lblod/ember-rdfa-editor": "^10.0.3",
-    "@lblod/ember-rdfa-editor-lblod-plugins": "22.3.0-dev.c89efc976b1b97b342236a6e3873d4fa770c80e6",
+    "@lblod/ember-rdfa-editor-lblod-plugins": "22.4.0",
     "@release-it-plugins/lerna-changelog": "^6.0.0",
     "broccoli-asset-rev": "^3.0.0",
     "changesets-release-it-plugin": "^0.1.2",

--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -161,6 +161,12 @@ snippets:
     id: Id
     snippet: Snippet
 
+snippet-edit:
+  sidebar:
+    general-nodes: General nodes
+    decision-nodes: Decision nodes
+    regulatory-statement-nodes: Regulatory statement nodes
+
 editor-document-title:
   placeholder: Untitled document
   change-title: Change title

--- a/translations/nl-BE.yaml
+++ b/translations/nl-BE.yaml
@@ -161,6 +161,12 @@ snippets:
     id: Id
     snippet: Fragment
 
+snippet-edit:
+  sidebar:
+    general-nodes: Algemene nodes
+    decision-nodes: Besluit nodes
+    regulatory-statement-nodes: Reglementaire Bijlage nodes
+
 editor-document-title:
   placeholder: Naamloos document
   change-title: Titel wijzigen


### PR DESCRIPTION
## Overview
This (draft) PR adds two different features/adjustments:
- Support for inserting decision articles in snippets
- A restructure of the snippet editor sidebar which now contains 3 seperate insert sections:
   * Algemene nodes (General nodes): contains actions such as inserting dates, citations etc.
   * Besluit nodes (Decision nodes): contains actions such as inserting a mandatee table, decision article
   * Reglementaire Bijlage nodes (Regulatory statement nodes): contains actions such as inserting article structures, document titles

##### connected issues and PRs:
https://github.com/lblod/ember-rdfa-editor-lblod-plugins/pull/471

### How to test/reproduce
- Start the application
- Open a snippet in the editor
- Notice that the sidebar is now divided into 3 insert sections
- You should be able to insert decision articles anywhere in the snippet

### Challenges/uncertainties
Unsure about the naming of these insert sections. (should the general section be open by default? should we add a similar two-way division to the main template editor?)

### Checks PR readiness
- [x] UI: works on smaller screen sizes
- [x] UI: feedback for any loading/error states
- [x] Check cancel/go-back flows
- [x] Check database state correct when deleting/updating (especially regarding relationships)
- [x] npm lint
- [x] no new deprecations
- [ ] changelog
