### PR TITLE
Remove person variable edit components as templates can't contain people

### DIFF
--- a/.changeset/lovely-buckets-press.md
+++ b/.changeset/lovely-buckets-press.md
@@ -1,0 +1,5 @@
+---
+"frontend-reglementaire-bijlage": patch
+---
+
+Disallow inserting a person into a person variable placeholder, as there is no meaningful list of people since the user is not linked to a municipality

--- a/app/templates/snippet-management/edit/edit-snippet.hbs
+++ b/app/templates/snippet-management/edit/edit-snippet.hbs
@@ -174,10 +174,6 @@
             @controller={{this.editor}}
             @options={{this.config.date}}
           />
-          <VariablePlugin::Person::Edit
-            @controller={{this.editor}}
-            @config={{this.config.lmb}}
-          />
           <TemplateCommentsPlugin::EditCard @controller={{this.editor}} />
         </Sidebar>
       {{/if}}

--- a/app/templates/template-management/edit.hbs
+++ b/app/templates/template-management/edit.hbs
@@ -221,10 +221,6 @@
             @controller={{this.editor}}
             @options={{this.config.date}}
           />
-          <VariablePlugin::Person::Edit
-            @controller={{this.editor}}
-            @config={{this.config.lmb}}
-          />
           <TemplateCommentsPlugin::EditCard @controller={{this.editor}} />
           {{! VariablePlugin::TemplateVariableCard is not added on purpose
           as an RB-document creator should not be able to set a "default" codelist option.}}


### PR DESCRIPTION
## Overview
The user of RB is not from any municipality, so there's no meaningful list of people that they could insert. Further, if they could insert any 'person', then this would make templates that are specific to the relevant municipality for that person, which does not make sense.

##### connected issues and PRs:
Although https://github.com/lblod/app-reglementaire-bijlage/pull/82 makes vendor-proxy work, there are still no people to insert.
Part of Jira ticket https://binnenland.atlassian.net/browse/GN-5018

### Setup
N/A

### How to test/reproduce
You can insert person placeholders using the variable drop-down, but not insert the actual person.

### Challenges/uncertainties
N/A

### Checks PR readiness
- [ ] UI: works on smaller screen sizes
- [ ] UI: feedback for any loading/error states
- [ ] Check cancel/go-back flows
- [ ] Check database state correct when deleting/updating (especially regarding relationships)
- [ ] changelog
- [ ] npm lint
- [ ] no new deprecations