### PR TITLE
Feat/add autofilled variable

### DIFF
--- a/app/controllers/snippet-management/edit/edit-snippet.js
+++ b/app/controllers/snippet-management/edit/edit-snippet.js
@@ -70,6 +70,8 @@ import {
   text_variable,
   personVariableView,
   person_variable,
+  autofilled_variable,
+  autofilledVariableView
 } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/variable-plugin/variables';
 import { document_title } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/document-title-plugin/nodes';
 import {
@@ -85,6 +87,7 @@ import DateInsertVariableComponent from '@lblod/ember-rdfa-editor-lblod-plugins/
 import CodelistInsertComponent from '@lblod/ember-rdfa-editor-lblod-plugins/components/variable-plugin/codelist/insert';
 import VariablePluginAddressInsertVariableComponent from '@lblod/ember-rdfa-editor-lblod-plugins/components/variable-plugin/address/insert-variable';
 import PersonVariableInsertComponent from '@lblod/ember-rdfa-editor-lblod-plugins/components/variable-plugin/person/insert';
+import AutofilledInsertComponent from '@lblod/ember-rdfa-editor-lblod-plugins/components/variable-plugin/autofilled/insert';
 
 import {
   editableNodePlugin,
@@ -143,6 +146,7 @@ export default class SnippetManagementEditSnippetController extends Controller {
       oslo_location: osloLocation(this.config.location),
       text_variable,
       person_variable,
+      autofilled_variable: autofilled_variable(this.config.autofilledVariable),
       number,
       codelist,
       ...STRUCTURE_NODES,
@@ -206,6 +210,10 @@ export default class SnippetManagementEditSnippetController extends Controller {
         label: this.intl.t('editor.variables.person'),
         component: PersonVariableInsertComponent,
       },
+      {
+        label: 'autofilled',
+        component: AutofilledInsertComponent
+      },
     ];
   }
 
@@ -262,6 +270,9 @@ export default class SnippetManagementEditSnippetController extends Controller {
       lmb: {
         endpoint: '/vendor-proxy/query',
       },
+      autofilledVariable: {
+        autofilledValues: {}
+      }
     };
   }
 
@@ -281,6 +292,7 @@ export default class SnippetManagementEditSnippetController extends Controller {
         person_variable: personVariableView(controller),
         inline_rdfa: inlineRdfaWithConfigView({ rdfaAware: true })(controller),
         oslo_location: osloLocationView(this.config.location)(controller),
+        autofilled_variable: autofilledVariableView(this.config.autofilledVariable)(controller)
       };
     };
   }

--- a/app/controllers/snippet-management/edit/edit-snippet.js
+++ b/app/controllers/snippet-management/edit/edit-snippet.js
@@ -100,6 +100,7 @@ import {
   osloLocation,
   osloLocationView,
 } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/location-plugin/node';
+import { variableAutofillerPlugin } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/variable-plugin/plugins/autofiller';
 
 export default class SnippetManagementEditSnippetController extends Controller {
   AttributeEditor = AttributeEditor;
@@ -146,7 +147,7 @@ export default class SnippetManagementEditSnippetController extends Controller {
       oslo_location: osloLocation(this.config.location),
       text_variable,
       person_variable,
-      autofilled_variable: autofilled_variable(this.config.autofilledVariable),
+      autofilled_variable,
       number,
       codelist,
       ...STRUCTURE_NODES,
@@ -292,7 +293,7 @@ export default class SnippetManagementEditSnippetController extends Controller {
         person_variable: personVariableView(controller),
         inline_rdfa: inlineRdfaWithConfigView({ rdfaAware: true })(controller),
         oslo_location: osloLocationView(this.config.location)(controller),
-        autofilled_variable: autofilledVariableView(this.config.autofilledVariable)(controller)
+        autofilled_variable: autofilledVariableView(controller)
       };
     };
   }
@@ -305,6 +306,7 @@ export default class SnippetManagementEditSnippetController extends Controller {
       linkPasteHandler(this.schema.nodes.link),
       listTrackingPlugin(),
       editableNodePlugin(),
+      variableAutofillerPlugin(this.config.autofilledVariable),
     ];
   }
 

--- a/app/controllers/template-management/edit.js
+++ b/app/controllers/template-management/edit.js
@@ -71,6 +71,8 @@ import {
   text_variable,
   personVariableView,
   person_variable,
+  autofilled_variable,
+  autofilledVariableView
 } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/variable-plugin/variables';
 import { document_title } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/document-title-plugin/nodes';
 import {
@@ -86,6 +88,7 @@ import NumberInsertComponent from '@lblod/ember-rdfa-editor-lblod-plugins/compon
 import DateInsertVariableComponent from '@lblod/ember-rdfa-editor-lblod-plugins/components/variable-plugin/date/insert-variable';
 import CodelistInsertComponent from '@lblod/ember-rdfa-editor-lblod-plugins/components/variable-plugin/codelist/insert';
 import VariablePluginAddressInsertVariableComponent from '@lblod/ember-rdfa-editor-lblod-plugins/components/variable-plugin/address/insert-variable';
+import AutofilledInsertComponent from '@lblod/ember-rdfa-editor-lblod-plugins/components/variable-plugin/autofilled/insert';
 import { DECISION_STANDARD_FOLDER } from '../../utils/constants';
 import {
   editableNodePlugin,
@@ -170,6 +173,7 @@ export default class TemplateManagementEditController extends Controller {
       text_variable,
       oslo_location: osloLocation(this.config.location),
       person_variable,
+      autofilled_variable: autofilled_variable(this.config.autofilledVariable),
       number,
       codelist,
       ...STRUCTURE_NODES,
@@ -236,6 +240,10 @@ export default class TemplateManagementEditController extends Controller {
       {
         label: this.intl.t('editor.variables.person'),
         component: PersonVariableInsertComponent,
+      },
+      {
+        label: 'autofilled',
+        component: AutofilledInsertComponent
       },
     ];
   }
@@ -321,6 +329,9 @@ export default class TemplateManagementEditController extends Controller {
         defaultAddressUriRoot:
           'https://publicatie.gelinkt-notuleren.vlaanderen.be/id/adres/',
       },
+      autofilledVariable: {
+        autofilledValues: {}
+      }
     };
   }
 
@@ -343,6 +354,7 @@ export default class TemplateManagementEditController extends Controller {
         snippet_placeholder: snippetPlaceholderView(controller),
         mandatee_table: mandateeTableView(controller),
         structure: structureView(controller),
+        autofilled_variable: autofilledVariableView(this.config.autofilledVariable)(controller)
       };
     };
   }

--- a/app/controllers/template-management/edit.js
+++ b/app/controllers/template-management/edit.js
@@ -117,6 +117,7 @@ import {
   osloLocation,
   osloLocationView,
 } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/location-plugin/node';
+import { variableAutofillerPlugin } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/variable-plugin/plugins/autofiller';
 
 const SNIPPET_LISTS_IDS_DOCUMENT_ATTRIBUTE = 'data-snippet-list-ids';
 const GEMEENTE_CLASSIFICATION_URI =
@@ -173,7 +174,7 @@ export default class TemplateManagementEditController extends Controller {
       text_variable,
       oslo_location: osloLocation(this.config.location),
       person_variable,
-      autofilled_variable: autofilled_variable(this.config.autofilledVariable),
+      autofilled_variable,
       number,
       codelist,
       ...STRUCTURE_NODES,
@@ -354,7 +355,7 @@ export default class TemplateManagementEditController extends Controller {
         snippet_placeholder: snippetPlaceholderView(controller),
         mandatee_table: mandateeTableView(controller),
         structure: structureView(controller),
-        autofilled_variable: autofilledVariableView(this.config.autofilledVariable)(controller)
+        autofilled_variable: autofilledVariableView(controller)
       };
     };
   }
@@ -367,6 +368,7 @@ export default class TemplateManagementEditController extends Controller {
       linkPasteHandler(this.schema.nodes.link),
       listTrackingPlugin(),
       editableNodePlugin(),
+      variableAutofillerPlugin(this.config.autofilledVariable),
     ];
   }
   get activeNode() {

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,7 @@
         "@lblod/ember-environment-banner": "^0.5.0",
         "@lblod/ember-mock-login": "^0.10.0",
         "@lblod/ember-rdfa-editor": "^10.0.3",
-        "@lblod/ember-rdfa-editor-lblod-plugins": "^22.4.0-dev.f4f5f78d2b946ca6a707e6073494232191b21c2f",
+        "@lblod/ember-rdfa-editor-lblod-plugins": "22.4.0-dev.50a6c5f81776f1c4dfed1a1facd9df7087afe1c8",
         "@release-it-plugins/lerna-changelog": "^6.0.0",
         "broccoli-asset-rev": "^3.0.0",
         "changesets-release-it-plugin": "^0.1.2",
@@ -5123,9 +5123,9 @@
       }
     },
     "node_modules/@lblod/ember-rdfa-editor-lblod-plugins": {
-      "version": "22.4.0",
-      "resolved": "https://registry.npmjs.org/@lblod/ember-rdfa-editor-lblod-plugins/-/ember-rdfa-editor-lblod-plugins-22.4.0.tgz",
-      "integrity": "sha512-HEA31h0o7VdZQYn5a2gazpXxDuVRXHXCBhu4G/g2M0PPTjIrYRmnDuTF7ViE8IqRehJqP4A25Caf7UvoNw1qlw==",
+      "version": "22.4.0-dev.50a6c5f81776f1c4dfed1a1facd9df7087afe1c8",
+      "resolved": "https://registry.npmjs.org/@lblod/ember-rdfa-editor-lblod-plugins/-/ember-rdfa-editor-lblod-plugins-22.4.0-dev.50a6c5f81776f1c4dfed1a1facd9df7087afe1c8.tgz",
+      "integrity": "sha512-ArCn5HoCeLAOBQ+chm5MSMUcq1XZWA93rfGBvBz9c/dzraJKSC9wOGf1/kknHABgxWcQKkJeF1vZ8gJYwBNCZg==",
       "dev": true,
       "dependencies": {
         "@codemirror/lang-html": "^6.4.9",

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,7 @@
         "@lblod/ember-environment-banner": "^0.5.0",
         "@lblod/ember-mock-login": "^0.10.0",
         "@lblod/ember-rdfa-editor": "^10.0.3",
-        "@lblod/ember-rdfa-editor-lblod-plugins": "^22.2.2",
+        "@lblod/ember-rdfa-editor-lblod-plugins": "^22.4.0-dev.f4f5f78d2b946ca6a707e6073494232191b21c2f",
         "@release-it-plugins/lerna-changelog": "^6.0.0",
         "broccoli-asset-rev": "^3.0.0",
         "changesets-release-it-plugin": "^0.1.2",
@@ -5123,9 +5123,9 @@
       }
     },
     "node_modules/@lblod/ember-rdfa-editor-lblod-plugins": {
-      "version": "22.2.2",
-      "resolved": "https://registry.npmjs.org/@lblod/ember-rdfa-editor-lblod-plugins/-/ember-rdfa-editor-lblod-plugins-22.2.2.tgz",
-      "integrity": "sha512-D3oJbbPYWYHijCyPMmpHs5lwjmUYQ3UINwF+UYsDO+DC3OwQ7RzYM79f3pJasv+A+NoBIiEmRB4BDAAGM1JhGQ==",
+      "version": "22.4.0",
+      "resolved": "https://registry.npmjs.org/@lblod/ember-rdfa-editor-lblod-plugins/-/ember-rdfa-editor-lblod-plugins-22.4.0.tgz",
+      "integrity": "sha512-HEA31h0o7VdZQYn5a2gazpXxDuVRXHXCBhu4G/g2M0PPTjIrYRmnDuTF7ViE8IqRehJqP4A25Caf7UvoNw1qlw==",
       "dev": true,
       "dependencies": {
         "@codemirror/lang-html": "^6.4.9",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "@lblod/ember-environment-banner": "^0.5.0",
     "@lblod/ember-mock-login": "^0.10.0",
     "@lblod/ember-rdfa-editor": "^10.0.3",
-    "@lblod/ember-rdfa-editor-lblod-plugins": "^22.4.0-dev.f4f5f78d2b946ca6a707e6073494232191b21c2f",
+    "@lblod/ember-rdfa-editor-lblod-plugins": "22.4.0-dev.50a6c5f81776f1c4dfed1a1facd9df7087afe1c8",
     "@release-it-plugins/lerna-changelog": "^6.0.0",
     "broccoli-asset-rev": "^3.0.0",
     "changesets-release-it-plugin": "^0.1.2",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "@lblod/ember-environment-banner": "^0.5.0",
     "@lblod/ember-mock-login": "^0.10.0",
     "@lblod/ember-rdfa-editor": "^10.0.3",
-    "@lblod/ember-rdfa-editor-lblod-plugins": "^22.2.2",
+    "@lblod/ember-rdfa-editor-lblod-plugins": "^22.4.0-dev.f4f5f78d2b946ca6a707e6073494232191b21c2f",
     "@release-it-plugins/lerna-changelog": "^6.0.0",
     "broccoli-asset-rev": "^3.0.0",
     "changesets-release-it-plugin": "^0.1.2",


### PR DESCRIPTION
## Overview
Implement https://github.com/lblod/ember-rdfa-editor-lblod-plugins/pull/472

##### connected issues and PRs:
GN-4901


### How to test/reproduce
You can check that you can now add autofill variables in both templates and snippets, that will be autofilled later in GN

### Challenges/uncertainties
Will there be any variable that can be autofilled in RB if the context is right? I can see a reason not to include the plugin in here


### Checks PR readiness
- [ ] UI: works on smaller screen sizes
- [ ] UI: feedback for any loading/error states
- [ ] Check cancel/go-back flows
- [ ] Check database state correct when deleting/updating (especially regarding relationships)
- [ ] changelog
- [ ] npm lint
- [ ] no new deprecations