### PR TITLE
GN-4956: search bar rework

### DIFF
--- a/.changeset/strong-tomatoes-bake.md
+++ b/.changeset/strong-tomatoes-bake.md
@@ -1,0 +1,5 @@
+---
+"frontend-reglementaire-bijlage": minor
+---
+
+Addition of `search-form` component containing explicit search button

--- a/app/components/search-form.hbs
+++ b/app/components/search-form.hbs
@@ -1,0 +1,14 @@
+<form role="search" onsubmit={{@onSearch}} ...attributes>
+  <span class="search-form">
+    <input
+      name="query"
+      type="search"
+      aria-label={{t 'search-form.aria-label'}}
+      {{on "input" @onInput}}
+      value={{@value}}
+      placeholder={{@placeholder}}
+      class="search-form__input"
+    />
+    <button type="submit" class="search-form__submit"><AuIcon @icon="search"/></button>
+  </span>
+</form>

--- a/app/controllers/codelist-management/index.js
+++ b/app/controllers/codelist-management/index.js
@@ -1,30 +1,36 @@
 import Controller from '@ember/controller';
-import { restartableTask, timeout } from 'ember-concurrency';
 import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
 import { inject as service } from '@ember/service';
 import { task } from 'ember-concurrency';
+import { localCopy } from 'tracked-toolbox';
 
 export default class CodelistManagementIndexController extends Controller {
   @service router;
 
   queryParams = ['page', 'size', 'label', 'sort'];
-
   @tracked page = 0;
   @tracked size = 20;
   @tracked label = '';
   @tracked sort = '-created-on';
+
+  @localCopy('label', '') searchQuery;
+
   @tracked isRemoveModalOpen = false;
   @tracked modalCodelist;
 
-  updateSearchFilterTask = restartableTask(
-    async (queryParamProperty, event) => {
-      await timeout(300);
+  @action
+  updateSearchQuery(event) {
+    event.preventDefault();
+    this.searchQuery = event.target.value;
+  }
 
-      this[queryParamProperty] = event.target.value.trim();
-      this.resetPagination();
-    },
-  );
+  @action
+  search(event) {
+    event.preventDefault();
+    this.label = this.searchQuery;
+    this.resetPagination();
+  }
 
   resetPagination() {
     this.page = 0;

--- a/app/controllers/snippet-management/index.js
+++ b/app/controllers/snippet-management/index.js
@@ -1,31 +1,38 @@
 import Controller from '@ember/controller';
-import { restartableTask, timeout } from 'ember-concurrency';
 import { service } from '@ember/service';
 import { task } from 'ember-concurrency';
 import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
+import { localCopy } from 'tracked-toolbox';
 
 export default class SnippetManagementIndexController extends Controller {
   @service store;
   @service router;
   @service currentSession;
-  queryParams = ['page', 'size', 'label', 'sort'];
 
+  queryParams = ['page', 'size', 'label', 'sort'];
   @tracked page = 0;
   @tracked size = 20;
   @tracked label = '';
   @tracked sort = '-created-on';
+
+  @localCopy('label', '') searchQuery;
+
   @tracked isRemoveModalOpen = false;
   @tracked deletingSnippetList;
 
-  updateSearchFilterTask = restartableTask(
-    async (queryParamProperty, event) => {
-      await timeout(300);
+  @action
+  updateSearchQuery(event) {
+    event.preventDefault();
+    this.searchQuery = event.target.value;
+  }
 
-      this[queryParamProperty] = event.target.value.trim();
-      this.resetPagination();
-    },
-  );
+  @action
+  search(event) {
+    event.preventDefault();
+    this.label = this.searchQuery;
+    this.resetPagination();
+  }
 
   resetPagination() {
     this.page = 0;

--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -101,3 +101,51 @@ div.table-of-contents {
   display: flex;
   flex-direction: column;
 }
+
+
+.search-form {
+  border: 0.1rem solid var(--au-gray-300);
+  border-radius: 0.3rem;
+  color: var(--au-gray-1000);
+  font-size: var(--au-h6);
+  height: 3.6rem;
+  display: flex;
+  flex-direction: row;
+
+  &:focus-within {
+    outline: none;
+    border-width: 0.1rem;
+    border-color: var(--au-outline-color);
+    box-shadow: inset 0 0 0 0.2rem var(--au-outline-color);
+  }
+
+  &__input {
+    border: 0;
+    flex-grow: 1;
+    box-shadow: none;
+    background-color: transparent;
+
+    font-size: inherit;
+    padding-left: 1.2rem;
+
+    &:focus {
+      outline: none;
+      border: none;
+      box-shadow: none;
+    }
+  }
+
+  &__submit {
+    border: none;
+    box-shadow: none;
+    background-color: transparent;
+    cursor: pointer;
+    padding: 0;
+    margin-left: 0.2rem;
+    margin-right: 1.2rem;
+    svg {
+      width: 1.6rem;
+      height: 100%;
+    }
+  }
+}

--- a/app/templates/codelist-management/index.hbs
+++ b/app/templates/codelist-management/index.hbs
@@ -17,16 +17,12 @@
         <Group class="au-c-toolbar__group--center">
           {{! Copied from the AuDataTable::TextSearch component since that doesn't support calling actions on input}}
           <div class="au-c-data-table__search">
-            <input
-              value={{this.label}}
-              placeholder={{t "codelist.crud.label-filter"}}
-              aria-label={{t "codelist.crud.label-filter"}}
-              class="au-c-input au-c-input--block"
-              {{on "input" (perform this.updateSearchFilterTask "label")}}
+            <SearchForm
+              @value={{this.searchQuery}}
+              @placeholder={{t "codelist.crud.label-filter"}}
+              @onInput={{this.updateSearchQuery}}
+              @onSearch={{this.search}}
             />
-            <span class="au-c-data-table__search-icon">
-              <AuIcon @icon="search" @size="large" />
-            </span>
           </div>
           <AuLink
             @route="codelist-management.new"

--- a/app/templates/snippet-management/index.hbs
+++ b/app/templates/snippet-management/index.hbs
@@ -15,18 +15,14 @@
               {{t "snippets.manage-snippet-lists"}}
             </AuHeading>
           </Group>
-          <Group>
+          <Group class="au-c-toolbar__group--center">
             <div class="au-c-data-table__search">
-              <input
-                value={{this.label}}
-                placeholder={{t "snippets.crud.label-filter"}}
-                aria-label={{t "snippets.crud.label-filter"}}
-                class="au-c-input au-c-input--block"
-                {{on "input" (perform this.updateSearchFilterTask "label")}}
+              <SearchForm
+                @value={{this.searchQuery}}
+                @placeholder={{t "snippets.crud.label-filter"}}
+                @onInput={{this.updateSearchQuery}}
+                @onSearch={{this.search}}
               />
-              <span class="au-c-data-table__search-icon">
-                <AuIcon @icon="search" @size="large" />
-              </span>
             </div>
             <AuLink
               @skin="button"

--- a/app/templates/template-management/index.hbs
+++ b/app/templates/template-management/index.hbs
@@ -16,18 +16,14 @@
             {{t "template-management.page-title"}}
           </AuHeading>
         </Group>
-        <Group class="au-c-toolbar__group--center">
+        <Group class="au-c-toolbar__group--center" >
           <div class="au-c-data-table__search ">
-            <input
-              aria-label={{t "template-management.crud.label-filter"}}
-              value={{this.title}}
-              placeholder={{t "template-management.crud.label-filter"}}
-              class="au-c-input au-c-input--block"
-              {{on "input" (perform this.updateSearchFilterTask "title")}}
+            <SearchForm
+              @value={{this.searchQuery}}
+              @placeholder={{t "template-management.crud.label-filter"}}
+              @onInput={{this.updateSearchQuery}}
+              @onSearch={{this.search}}
             />
-            <span class="au-c-data-table__search-icon">
-              <AuIcon @icon="search" @size="large" />
-            </span>
           </div>
           {{#unless this.readOnly}}
             <AuButton

--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -179,3 +179,6 @@ editor:
     date: date
     codelist: codelist
     person: person
+
+search-form:
+  aria-label: Search

--- a/translations/nl-BE.yaml
+++ b/translations/nl-BE.yaml
@@ -179,3 +179,6 @@ editor:
     date: datum
     codelist: codelijst
     person: persoon
+
+search-form:
+  aria-label: Zoek


### PR DESCRIPTION
## Overview
This PR includes a rework of the search-form/search-bar which is used on the 3 main overview pages:
- snippet-management
- codelist-management
- template-management

Specifically, the rework includes:
- A new reusable `search-form` component, with an explicit button
- No automatic searches. Search is only performed when clicking the search-icon/button, or pressing enter
- Removal of debounced search, as it is no longer needed.

##### connected issues and PRs:
Fixes [GN-4956](https://binnenland.atlassian.net/browse/GN-4956?atlOrigin=eyJpIjoiYTRhZjExMzExMTNhNDE2NmEyNjE4M2QwMjYyMzY4OWUiLCJwIjoiaiJ9)


### Setup
None

### How to test/reproduce
- Start the application
- Visit any of the overview screens
- Ensure you can search the items using the new search form
- The search form should also be navigable with `tab`.
- You should be able to use `Enter` to search
- The pages do not completely reload
- The query parameters are correctly updated
- When reloading a page, the search-field is populated with the query parameter 

### Challenges/uncertainties
- I used a `form` element of the search-bar, as that seemed the best/most accessible to me.
- Should we put the `...attributes` on the `form` element or `input` element
- Is the button accessible/clear enough?
- This is quite a change in UX, maybe we should consult designers/PMs first?

### Checks PR readiness
- [x] UI: works on smaller screen sizes
- [x] UI: feedback for any loading/error states
- [x] Check cancel/go-back flows
- [x] Check database state correct when deleting/updating (especially regarding relationships)
- [x] changelog
- [x] npm lint
- [x] no new deprecations