### PR TITLE
Fix bug with empty lines being removed on save

### DIFF
--- a/.changeset/lemon-tables-yawn.md
+++ b/.changeset/lemon-tables-yawn.md
@@ -1,0 +1,5 @@
+---
+"frontend-reglementaire-bijlage": patch
+---
+
+Fix removal of empty lines on save, they are now maintained

--- a/app/controllers/snippet-management/edit/edit-snippet.js
+++ b/app/controllers/snippet-management/edit/edit-snippet.js
@@ -335,7 +335,7 @@ export default class SnippetManagementEditSnippetController extends Controller {
   handleRdfaEditorInit(editor) {
     this.editor = editor;
     if (this.editorDocument.content) {
-      editor.initialize(this.editorDocument.content);
+      editor.initialize(this.editorDocument.content, { doNotClean: true });
     }
   }
 

--- a/app/controllers/template-management/edit.js
+++ b/app/controllers/template-management/edit.js
@@ -383,7 +383,7 @@ export default class TemplateManagementEditController extends Controller {
   handleRdfaEditorInit(editor) {
     this.editor = editor;
     if (this.editorDocument.content) {
-      editor.initialize(this.editorDocument.content);
+      editor.initialize(this.editorDocument.content, { doNotClean: true });
       this.assignedSnippetListsIds = this.documentSnippetListIds;
     } else if (this.model?.templateTypeId === DECISION_STANDARD_FOLDER) {
       // This is a decision with no content, so we need to insert a decision (besluit) node so that

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,8 +33,8 @@
         "@lblod/ember-acmidm-login": "^2.1.0",
         "@lblod/ember-environment-banner": "^0.5.0",
         "@lblod/ember-mock-login": "^0.10.0",
-        "@lblod/ember-rdfa-editor": "10.3.0-dev.c73b724b9cdc8d9eae92504ab5c64e96e31b7797",
-        "@lblod/ember-rdfa-editor-lblod-plugins": "22.4.1-dev.c60cd154c2d32d1a61fce102170790cf5b5afd1f",
+        "@lblod/ember-rdfa-editor": "10.4.0-dev.d5b99c1843ff85a4e03c2cb8de08d1329d8184e3",
+        "@lblod/ember-rdfa-editor-lblod-plugins": "^22.5.1",
         "@release-it-plugins/lerna-changelog": "^6.0.0",
         "broccoli-asset-rev": "^3.0.0",
         "changesets-release-it-plugin": "^0.1.2",
@@ -5034,9 +5034,9 @@
       }
     },
     "node_modules/@lblod/ember-rdfa-editor": {
-      "version": "10.3.0-dev.c73b724b9cdc8d9eae92504ab5c64e96e31b7797",
-      "resolved": "https://registry.npmjs.org/@lblod/ember-rdfa-editor/-/ember-rdfa-editor-10.3.0-dev.c73b724b9cdc8d9eae92504ab5c64e96e31b7797.tgz",
-      "integrity": "sha512-pTZ91yPS1/TbV6iyMwzLtbjiHoa41XLVmXSFKYvDsljoJzOutria61+kGzjNlvovf8FhAiMBEMlEFmsaqxzEBw==",
+      "version": "10.4.0-dev.d5b99c1843ff85a4e03c2cb8de08d1329d8184e3",
+      "resolved": "https://registry.npmjs.org/@lblod/ember-rdfa-editor/-/ember-rdfa-editor-10.4.0-dev.d5b99c1843ff85a4e03c2cb8de08d1329d8184e3.tgz",
+      "integrity": "sha512-fk0hYWqSMLLuPwsJW/HveWB1kvM/XgtqZaRhO3KSDBTJ6Y/y4dpSVLYR6Yf66TJxUx7CVezmFM4rs4LtAfmW3Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5092,7 +5092,6 @@
         "tracked-built-ins": "^3.3.0",
         "tracked-toolbox": "^2.0.0",
         "uuid": "^9.0.1",
-        "vm-browserify": "^1.1.2",
         "yup": "^1.4.0"
       },
       "engines": {
@@ -5124,9 +5123,9 @@
       }
     },
     "node_modules/@lblod/ember-rdfa-editor-lblod-plugins": {
-      "version": "22.4.1-dev.c60cd154c2d32d1a61fce102170790cf5b5afd1f",
-      "resolved": "https://registry.npmjs.org/@lblod/ember-rdfa-editor-lblod-plugins/-/ember-rdfa-editor-lblod-plugins-22.4.1-dev.c60cd154c2d32d1a61fce102170790cf5b5afd1f.tgz",
-      "integrity": "sha512-A6aLCDbtrDYpFg+QYw7m17kfk93u4aD71iomGBtlA8tc7bJ76jXPqWleWMJ6fHQMEpbvJWcEmm2OgldJg4uUjQ==",
+      "version": "22.5.1",
+      "resolved": "https://registry.npmjs.org/@lblod/ember-rdfa-editor-lblod-plugins/-/ember-rdfa-editor-lblod-plugins-22.5.1.tgz",
+      "integrity": "sha512-5IfMtbSYUpgSDIESHbvOiM7mXHDwK/IbR08CMKXgcw8R2MX8idxWvuYzeEFii67GJdyqZCYTornvKN+p74+0lQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5170,7 +5169,7 @@
         "@appuniversum/ember-appuniversum": "^3.4.1",
         "@ember/string": "3.x",
         "@glint/template": "^1.4.0",
-        "@lblod/ember-rdfa-editor": "10.3.0-dev.c73b724b9cdc8d9eae92504ab5c64e96e31b7797",
+        "@lblod/ember-rdfa-editor": "^10.0.2",
         "ember-concurrency": "^3.1.0",
         "ember-element-helper": "^0.8.6",
         "ember-intl": "^7.0.0",
@@ -40219,12 +40218,6 @@
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
       }
-    },
-    "node_modules/vm-browserify": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-1.1.2.tgz",
-      "integrity": "sha512-2ham8XPWTONajOR0ohOKOHXkm3+gaBmGut3SRuu75xLd/RRaY6vqgh8NBYYk7+RW3u5AtzPQZG8F10LHkl0lAQ==",
-      "dev": true
     },
     "node_modules/vm2": {
       "version": "3.9.19",

--- a/package.json
+++ b/package.json
@@ -43,8 +43,8 @@
     "@lblod/ember-acmidm-login": "^2.1.0",
     "@lblod/ember-environment-banner": "^0.5.0",
     "@lblod/ember-mock-login": "^0.10.0",
-    "@lblod/ember-rdfa-editor": "10.3.0-dev.c73b724b9cdc8d9eae92504ab5c64e96e31b7797",
-    "@lblod/ember-rdfa-editor-lblod-plugins": "22.4.1-dev.c60cd154c2d32d1a61fce102170790cf5b5afd1f",
+    "@lblod/ember-rdfa-editor": "10.4.0-dev.d5b99c1843ff85a4e03c2cb8de08d1329d8184e3",
+    "@lblod/ember-rdfa-editor-lblod-plugins": "^22.5.1",
     "@release-it-plugins/lerna-changelog": "^6.0.0",
     "broccoli-asset-rev": "^3.0.0",
     "changesets-release-it-plugin": "^0.1.2",
@@ -100,6 +100,9 @@
     "@appuniversum/ember-appuniversum": {
       "@floating-ui/dom": "^1.6.5",
       "tracked-toolbox": "^2.0.0"
+    },
+    "@lblod/ember-rdfa-editor-lblod-plugins": {
+      "@lblod/ember-rdfa-editor": "10.4.0-dev.d5b99c1843ff85a4e03c2cb8de08d1329d8184e3"
     },
     "ember-data-table": {
       "ember-auto-import": "^2.6.3",


### PR DESCRIPTION
## Overview
Uses a new version of the editor with the option to skip html cleaning steps on initialize.

##### connected issues and PRs:
Editor PR to add the option: https://github.com/lblod/ember-rdfa-editor/pull/1217

### Setup
N/A

### How to test/reproduce
Create empty lines in a template or snippet. Click save. These lines are no longer removed from the editor content.

### Challenges/uncertainties
N/A

### Checks PR readiness
- [ ] UI: works on smaller screen sizes
- [ ] UI: feedback for any loading/error states
- [x] Check cancel/go-back flows
- [x] Check database state correct when deleting/updating (especially regarding relationships)
- [x] changelog
- [x] npm lint
- [x] no new deprecations