### PR TITLE
i18n: restructure snippet translations

### DIFF
--- a/.changeset/violet-tips-fly.md
+++ b/.changeset/violet-tips-fly.md
@@ -1,0 +1,5 @@
+---
+"frontend-reglementaire-bijlage": patch
+---
+
+Restructure snippet translations and improve/correct some snippet translations

--- a/app/components/snippet-list-form.hbs
+++ b/app/components/snippet-list-form.hbs
@@ -1,10 +1,10 @@
 <div class="au-u-margin-bottom">
   <AuFormRow>
     <AuLabel for="label">
-      {{t "snippets.snippet-label"}}
+      {{t "snippets.edit-snippet-list.form.label.label"}}
     </AuLabel>
     <p class="under-label-text">
-      {{t "snippets.snippet-label-explanation"}}
+      {{t "snippets.edit-snippet-list.form.label.description"}}
     </p>
     <div class="au-u-flex au-u-flex--vertical-center">
       <AuInput
@@ -20,7 +20,7 @@
             @skin="success"
             @icon="check"
           >
-            {{t "snippets.saved"}}
+            {{t "utility.saved"}}
           </AuPill>
         </div>
       {{/if}}
@@ -28,7 +28,7 @@
   </AuFormRow>
   <AuFormRow>
     <AuLabel for="imported-resources">
-      {{t "snippets.attr.imported"}}
+      {{t "snippets.edit-snippet-list.imported-resources.heading"}}
     </AuLabel>
     <AuTextarea
       id="imported-resources"
@@ -41,12 +41,12 @@
 <div class="snippets-table">
   <AuDataTable
     @content={{@model.snippets}}
-    @noDataMessage={{t "snippets.crud.no-data"}}
+    @noDataMessage={{t "snippets.edit-snippet-list.table.no-data"}}
     as |s|
   >
     <s.content as |c|>
       <c.header>
-        <th>{{t "snippets.attr.snippet"}}</th>
+        <th>{{t "snippets.edit-snippet-list.table.columns.snippet"}}</th>
         <th></th>
       </c.header>
       <c.body as |snippet|>
@@ -83,21 +83,21 @@
     {{on "click" (perform this.createSnippet)}}
     @loading={{this.createSnippet.isRunning}}
   >
-    {{t "snippets.add-new-snippet"}}
+    {{t "snippets.edit-snippet-list.snippet-creation.action"}}
   </AuButton>
 </div>
 <div class="snippet-list-template-table au-u-margin-top-huge">
   <AuHeading @skin="4" class="au-u-margin-bottom">
-    {{t "snippets.template.heading"}}
+    {{t 'snippets.edit-snippet-list.connected-templates.heading'}}
   </AuHeading>
   <AuDataTable
     @content={{@model.templates}}
-    @noDataMessage={{t "snippets.template.no-data"}}
+    @noDataMessage={{t 'snippets.edit-snippet-list.connected-templates.table.no-data'}}
     as |s|
   >
     <s.content as |c|>
       <c.header>
-        <th>{{t "snippets.template.table-header"}}</th>
+        <th>{{t 'snippets.edit-snippet-list.connected-templates.table.columns.template'}}</th>
       </c.header>
       <c.body as |template|>
         <td>
@@ -120,7 +120,11 @@
 >
   <Modal.Body>
     <p>
-      {{t 'snippets.crud.confirm-deletion-snippet' name=this.deletingSnippet.label htmlSafe=true}}
+      {{t
+        'snippets.edit-snippet-list.snippet-deletion.confirm'
+        name=this.deletingSnippet.label
+        htmlSafe=true
+      }}
     </p>
   </Modal.Body>
 <Modal.Footer>
@@ -130,7 +134,7 @@
     @loadingText={{t 'utility.deleting'}}
     {{on 'click' (perform this.removeSnippet)}}
   >
-    {{t 'snippets.crud.delete-snippet'}}
+    {{t 'snippets.edit-snippet-list.snippet-deletion.action.long'}}
   </AuButton>
   <AuButton @skin='secondary' {{on 'click' this.closeRemoveModal}}>
     {{t 'utility.cancel'}}

--- a/app/templates/snippet-management.hbs
+++ b/app/templates/snippet-management.hbs
@@ -1,7 +1,7 @@
-{{page-title (t 'snippets.manage-snippet-lists')}}
+{{page-title (t 'snippets.manage-snippet-lists.title')}}
 <BreadcrumbsItem as |linkClass|>
   <AuLink @route='snippet-management' class={{linkClass}}>
-    {{t 'snippets.manage-snippet-lists'}}
+    {{t 'snippets.manage-snippet-lists.title'}}
   </AuLink>
 </BreadcrumbsItem>
 {{outlet}}

--- a/app/templates/snippet-management/edit.hbs
+++ b/app/templates/snippet-management/edit.hbs
@@ -1,11 +1,11 @@
-{{page-title (t 'snippets.edit-snippet-list')}}
+{{page-title (t 'snippets.edit-snippet-list.title')}}
 <BreadcrumbsItem as |linkClass|>
   <AuLink
     @route='snippet-management.edit'
     @model={{this.model.id}}
     class={{linkClass}}
   >
-    {{t 'snippets.edit-snippet-list'}}
+    {{t 'snippets.edit-snippet-list.title'}}
   </AuLink>
 </BreadcrumbsItem>
 {{outlet}}

--- a/app/templates/snippet-management/edit/edit-snippet.hbs
+++ b/app/templates/snippet-management/edit/edit-snippet.hbs
@@ -1,6 +1,6 @@
-{{page-title (t "snippets.edit-snippet")}}
+{{page-title (t "snippets.edit-snippet.title")}}
 <BreadcrumbsItem>
-  {{t "snippets.edit-snippet"}}
+  {{t "snippets.edit-snippet.title"}}
 </BreadcrumbsItem>
 <AppChrome
   @editorDocument={{this.editorDocument}}

--- a/app/templates/snippet-management/edit/index.hbs
+++ b/app/templates/snippet-management/edit/index.hbs
@@ -4,7 +4,7 @@
       <div class='au-o-grid__item au-u-2-5@medium'>
         <div class='au-c-content au-u-margin-bottom'>
           <AuHeading @skin='2'>
-            {{t 'snippets.edit-snippet-list'}}
+            {{t 'snippets.edit-snippet-list.title'}}
           </AuHeading>
         </div>
       </div>

--- a/app/templates/snippet-management/index.hbs
+++ b/app/templates/snippet-management/index.hbs
@@ -2,7 +2,7 @@
   <AuDataTable
     @content={{this.model}}
     @fields="label importedResources"
-    @noDataMessage={{t "snippets.crud.no-data"}}
+    @noDataMessage={{t "snippets.manage-snippet-lists.table.no-data"}}
     @size={{this.size}}
     @page={{this.page}}
     @sort={{this.sort}} as |s|
@@ -12,14 +12,14 @@
         <AuToolbar class="au-o-box" as |Group|>
           <Group>
             <AuHeading @skin="2">
-              {{t "snippets.manage-snippet-lists"}}
+              {{t "snippets.manage-snippet-lists.title"}}
             </AuHeading>
           </Group>
           <Group class="au-c-toolbar__group--center">
             <div class="au-c-data-table__search">
               <SearchForm
                 @value={{this.searchQuery}}
-                @placeholder={{t "snippets.crud.label-filter"}}
+                @placeholder={{t "snippets.manage-snippet-lists.search.placeholder"}}
                 @onInput={{this.updateSearchQuery}}
                 @onSearch={{this.search}}
               />
@@ -28,7 +28,7 @@
               @skin="button"
               @route="snippet-management.new"
             >
-              {{t "snippets.make-new"}}
+              {{t "snippets.manage-snippet-lists.make-new"}}
             </AuLink>
           </Group>
         </AuToolbar>
@@ -39,10 +39,10 @@
         <AuDataTableThSortable
           @field=":no-case:label"
           @currentSorting={{this.sort}}
-          @label={{t "snippets.attr.label"}}
+          @label={{t "snippets.manage-snippet-lists.table.columns.label"}}
         />
-        <th>{{t "snippets.attr.id"}}</th>
-        <th>{{t "snippets.attr.imported"}}</th>
+        <th>{{t "snippets.manage-snippet-lists.table.columns.id"}}</th>
+        <th>{{t "snippets.manage-snippet-lists.table.columns.imported"}}</th>
         <th></th>
       </c.header>
       <c.body as |snippet|>
@@ -82,7 +82,11 @@
 >
   <Modal.Body>
     <p>
-      {{t 'snippets.crud.confirm-deletion' name=this.deletingSnippetList.label htmlSafe=true}}
+      {{t
+        'snippets.manage-snippet-lists.snippet-list-deletion.confirm'
+        name=this.deletingSnippetList.label
+        htmlSafe=true
+      }}
     </p>
   </Modal.Body>
 <Modal.Footer>
@@ -92,7 +96,7 @@
     @loadingText={{t 'utility.deleting'}}
     {{on 'click' (perform this.removeSnippetList)}}
   >
-    {{t 'snippets.crud.delete'}}
+    {{t 'snippets.manage-snippet-lists.snippet-list-deletion.action.long'}}
   </AuButton>
   <AuButton @skin='secondary' {{on 'click' this.closeRemoveModal}}>
     {{t 'utility.cancel'}}

--- a/app/templates/snippet-management/new.hbs
+++ b/app/templates/snippet-management/new.hbs
@@ -1,6 +1,6 @@
-{{page-title (t "snippets.edit-snippet-list")}}
+{{page-title (t "snippets.edit-snippet-list.title")}}
 <BreadcrumbsItem>
-    {{t "snippets.new-snippet-list"}}
+    {{t "snippets.new-snippet-list.title"}}
 </BreadcrumbsItem>
 <div class="au-c-body-container au-c-body-container--scroll">
   <div class="au-o-box">
@@ -8,7 +8,7 @@
       <div class="au-o-grid__item au-u-2-5@medium">
         <div class="au-c-content au-u-margin-bottom">
           <AuHeading @skin="2">
-            {{t "snippets.edit-snippet-list"}}
+            {{t "snippets.edit-snippet-list.title"}}
           </AuHeading>
         </div>
       </div>

--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -60,6 +60,7 @@ utility:
   field-required: This field is required
   type-something-placeholder: Type something...
   insert: Insert
+  saved: Saved
 landing-page:
   templates:
     title: Template management
@@ -135,32 +136,51 @@ static-page:
   cookie-policy: Cookie Policy
   accesibility-statement: Accessibility Statement
 snippets:
-  manage-snippet-lists: Manage snippet lists
-  make-new: Create new snippet list
-  create-snippet-list: Create snippet list
-  edit-snippet-list: Edit snippet list
-  new-snippet-list: New snippet list
-  edit-snippet: Edit snippet
-  snippet-label: Snippet label
-  snippet-label-explanation: Choose a label to refer to the snippet list
-  add-new-snippet: Add new snippet
-  saved: Saved
-  crud:
-    label-filter: Label
-    no-data: No snippet lists were found
-    confirm-deletion: Confirm to delete snippet list <strong>{name}</strong>
-    confirm-deletion-snippet: Confirm to delete snippet <strong>{name}</strong>
-    delete: Delete snippet list
-    delete-snippet: Delete snippet
-  template:
-    heading: Available in
-    table-header: Template
-    no-data: No templates connected to this snippet list
-  attr:
-    label: Label
-    id: Id
-    snippet: Snippet
-    imported: Imported Resources
+  manage-snippet-lists:
+    title: Manage snippet lists
+    make-new: Create new snippet list
+    table:
+      columns:
+        label: Label
+        id: Id
+        imported: Imported resources
+      no-data: No snippet lists were found
+    snippet-list-deletion:
+      confirm: Confirm to delete snippet list <strong>{name}</strong>
+      action:
+        short: Delete
+        long: Delete snippet list
+    search:
+      placeholder: Label
+  new-snippet-list:
+    title: New snippet list
+  edit-snippet-list:
+    title: Edit snippet list
+    form:
+      label:
+        label: Snippet list label
+        description: Choose a label to refer to the snippet list
+    imported-resources:
+      heading: Imported resources
+    table:
+      columns:
+        snippet: Snippet
+      no-data: No snippets were found
+    connected-templates:
+      heading: Available in
+      table:
+        columns:
+          template: Template
+        no-data: No templates connected to this snippet list
+    snippet-deletion:
+      confirm: Confirm to delete snippet <strong>{name}</strong>
+      action:
+        short: Delete
+        long: Delete snippet
+    snippet-creation:
+      action: Add new snippet
+  edit-snippet:
+    title: Edit snippet
 
 snippet-edit:
   sidebar:

--- a/translations/nl-BE.yaml
+++ b/translations/nl-BE.yaml
@@ -135,32 +135,51 @@ static-page:
   cookie-policy: Cookieverklaring
   accesibility-statement: Toegankelijkheidsverklaring
 snippets:
-  manage-snippet-lists: Beheer fragmentenlijsten
-  make-new: Maak nieuwe fragmentenlijst aan
-  create-snippet-list: Fragmentenlijsten aanmaken
-  edit-snippet-list: Fragmentenlijst bewerken
-  new-snippet-list: Nieuwe Fragmentenlijst
-  edit-snippet: Fragment bewerken
-  snippet-label: Fragment label
-  snippet-label-explanation: Kies een label om naar de fragmentenlijst te verwijzen
-  add-new-snippet: Nieuw fragment toevoegen
-  saved: Opgeslagen
-  crud:
-    label-filter: Label
-    no-data: Geen fragmenten gevonden
-    confirm-deletion: Bevestig om fragmentenlijst <strong>{name}</strong> te verwijderen
-    confirm-deletion-snippet: Bevestig om fragment <strong>{name}</strong> te verwijderen
-    delete: Fragmentenlijst verwijderen
-    delete-snippet: Fragment verwijderen
-  template:
-    heading: Beschikbaar in
-    table-header: Sjabloon
-    no-data: Geen sjablonen gekoppeld aan deze lijst met fragmenten
-  attr:
-    label: Label
-    id: Id
-    snippet: Fragment
-    imported: Ingevoerde Middelen
+  manage-snippet-lists:
+    title: Beheer fragmentlijsten
+    make-new: Maak nieuwe fragmentlijst aan
+    table:
+      columns:
+        label: Label
+        id: Id
+        imported: Geïmporteerde resources
+      no-data: Geen fragmentlijsten gevonden
+    snippet-list-deletion:
+      confirm: Bevestig om fragmentlijst <strong>{name}</strong> te verwijderen
+      action:
+        short: Verwijderen
+        long: Fragmentlijst verwijderen
+    search:
+      placeholder: Label
+  new-snippet-list:
+    title: Nieuwe fragmentlijst
+  edit-snippet-list:
+    title: Fragmentlijst bewerken
+    form:
+      label:
+        label: Label fragmentlijst
+        description: Kies een label om naar de fragmentlijst te verwijzen
+    imported-resources:
+      heading: Geïmporteerde resources
+    table:
+      columns:
+        snippet: Fragment
+      no-data: Geen fragmenten gevonden
+    connected-templates:
+      heading: Beschikbaar in
+      table:
+        columns:
+          template: Sjabloon
+        no-data: Geen sjablonen gekoppeld aan deze fragmentlijst
+    snippet-deletion:
+      confirm: Bevestig om fragment <strong>{name}</strong> te verwijderen
+      action:
+        short: Verwijderen
+        long: Fragment verwijderen
+    snippet-creation:
+      action: Fragment toevoegen
+  edit-snippet:
+    title: Fragment bewerken
 
 snippet-edit:
   sidebar:


### PR DESCRIPTION
## Overview
This PR includes two changes:
- A restructure of the snippet translations to better reflect the different routes/components
- Some corrections to the dutch translations + some new translations

##### connected issues and PRs:
None


### How to test/reproduce
- Open the app
- Visit the pages related to snippets
- The dutch translations should be improved/more correct
- Some translations (like the 'no-data' translations) should be more correct

### Challenges/uncertainties
I restructured the translations in a way that made more sense to me/is easier extendable, feel free to comment if you think the restructure is less clear/too verbose :)

### Checks PR readiness
- [x] UI: works on smaller screen sizes
- [x] UI: feedback for any loading/error states
- [x] Check cancel/go-back flows
- [x] Check database state correct when deleting/updating (especially regarding relationships)
- [x] changelog
- [x] npm lint
- [x] no new deprecations