### PR TITLE
Disable `rdfaAware` setting for `heading` nodes in snippet editor

### DIFF
--- a/.changeset/flat-drinks-know.md
+++ b/.changeset/flat-drinks-know.md
@@ -1,0 +1,5 @@
+---
+"frontend-reglementaire-bijlage": patch
+---
+
+Disable `rdfaAware` setting for heading nodes in snippets

--- a/app/controllers/snippet-management/edit/edit-snippet.js
+++ b/app/controllers/snippet-management/edit/edit-snippet.js
@@ -172,7 +172,7 @@ export default class SnippetManagementEditSnippetController extends Controller {
       codelist,
       ...STRUCTURE_NODES,
       mandatee_table,
-      heading: headingWithConfig({ rdfaAware: true }),
+      heading: headingWithConfig({ rdfaAware: false }),
       blockquote,
 
       horizontal_rule,


### PR DESCRIPTION
## Overview
This PR disables the `rdfaAware` setting for `heading` nodes in the snippet editor.
The `rdfaAware` setting never really worked very well in combination with `heading` nodes. Typically (IMO) it's not a good idea to mix markup/styled nodes (e.g. headings, paragraphs) with data nodes (block_rdfa, inline_rdfa...)

##### connected issues and PRs:
None

### Setup
None

### How to test/reproduce
- Start the frontend
- Open a snippet
- Insert any heading
- It should be non-rdfa aware, you should also be able to easily enter inside of it.

### Challenges/uncertainties
- In the future, we should probably parse heading nodes containing RDFa as `block_rdfa` nodes with a `heading` node inside. I'll make a Jira ticket to track this.

### Checks PR readiness
- [x] UI: works on smaller screen sizes
- [x] UI: feedback for any loading/error states
- [x] Check cancel/go-back flows
- [x] Check database state correct when deleting/updating (especially regarding relationships)
- [x] changelog
- [x] npm lint
- [x] no new deprecations