### PR TITLE
GN-5150: configure `emberApplication` prosemirror plugin

### DIFF
--- a/.changeset/spotty-plants-jump.md
+++ b/.changeset/spotty-plants-jump.md
@@ -1,0 +1,6 @@
+---
+"frontend-reglementaire-bijlage": patch
+---
+
+`rdfa-editor-container` component: include `emberApplication` prosemirror plugin by default.
+This ensures that the serialization method of prosemirror nodes will be able to leverage `ember-intl` to provide an internationalized node serialization.

--- a/app/components/rdfa-editor-container.js
+++ b/app/components/rdfa-editor-container.js
@@ -5,6 +5,8 @@ import { firefoxCursorFix } from '@lblod/ember-rdfa-editor/plugins/firefox-curso
 import { lastKeyPressedPlugin } from '@lblod/ember-rdfa-editor/plugins/last-key-pressed';
 import recreateUuidsOnPaste from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/variable-plugin/recreateUuidsOnPaste';
 import { chromeHacksPlugin } from '@lblod/ember-rdfa-editor/plugins/chrome-hacks-plugin';
+import { emberApplication } from '@lblod/ember-rdfa-editor/plugins/ember-application';
+import { getOwner } from '@ember/application';
 
 export default class RdfaEditorContainerComponent extends Component {
   @tracked editor;
@@ -36,6 +38,7 @@ export default class RdfaEditorContainerComponent extends Component {
       lastKeyPressedPlugin,
       chromeHacksPlugin(),
       recreateUuidsOnPaste,
+      emberApplication({ application: getOwner(this) }),
     );
   }
 


### PR DESCRIPTION
## Overview
This PR adds the `emberApplication` prosemirror plugin to the list of configured plugins for the snippet and template editors.
This ensures that the serialization methods of the configure prosemirror node-specs have access to the ember application, which allows them to leverage `ember-intl` to provide internationalized serializations.
This thus also fixes the non-internationalized article serialization bug.

##### connected issues and PRs:
[GN-5150](https://binnenland.atlassian.net/browse/GN-5150)

### Setup
None

### How to test/reproduce
- Start the app
- Open a template
- Add a decision article to the template
- Save the template and go to the publish screen
- Notice that the serialized article is now correctly internationalized (following the document language)

### Checks PR readiness
- [x] UI: works on smaller screen sizes
- [x] UI: feedback for any loading/error states
- [x] Check cancel/go-back flows
- [x] Check database state correct when deleting/updating (especially regarding relationships)
- [x] changelog
- [x] npm lint
- [x] no new deprecations