### PR TITLE
GN-5055: connected-snippet-lists - fix and extend functionality

### DIFF
--- a/.changeset/quick-falcons-flow.md
+++ b/.changeset/quick-falcons-flow.md
@@ -1,0 +1,11 @@
+---
+"frontend-reglementaire-bijlage": minor
+---
+
+Re-enable/extend connected documents feature:
+- `SnippetList` model: remove unnecessary `templates` relationship
+- `DocumentContainer` model: rename `snippetLists` relationship to `linkedSnippetLists`
+- `Snippet` model: add `linkedSnippetLists` relationship
+- Extend `snippet-list` edit page to include both connected templates *and* connected snippets
+- Add `@lblod/marawa` dependency to allow for RDFa document parsing
+- Ensure the connected snippet-lists are extracted and stored on saving templates/snippets

--- a/app/components/snippet-list-form.hbs
+++ b/app/components/snippet-list-form.hbs
@@ -59,7 +59,11 @@
               @closable={{false}}
               @title={{t "snippets.edit-snippet-list.table.loading-error"}}
             >
-              <AuButton @skin="link" {{on "click" this.snippetsRequest.retry}} class="au-u-padding-none">
+              <AuButton
+                @skin="link"
+                {{on "click" this.snippetsRequest.retry}}
+                class="au-u-padding-none"
+              >
                 {{t "utility.retry"}}
               </AuButton>
             </AuAlert>
@@ -122,34 +126,68 @@
 </div>
 <div class="snippet-list-template-table au-u-margin-top-huge">
   <AuHeading @skin="4" class="au-u-margin-bottom">
-    {{t "snippets.edit-snippet-list.connected-templates.heading"}}
+    {{t "snippets.edit-snippet-list.connected-documents.heading"}}
   </AuHeading>
-  <AuDataTable
-    @content={{@snippetList.templates}}
-    @noDataMessage={{t
-      "snippets.edit-snippet-list.connected-templates.table.no-data"
-    }}
-    as |s|
-  >
-    <s.content as |c|>
-      <c.header>
-        <th>{{t
-            "snippets.edit-snippet-list.connected-templates.table.columns.template"
-          }}</th>
-      </c.header>
-      <c.body as |template|>
-        <td>
-          <AuLink
-            @skin="primary"
-            @route="template-management.edit"
-            @model={{template.id}}
-          >
-            {{template.currentVersion.title}}
-          </AuLink>
-        </td>
-      </c.body>
-    </s.content>
-  </AuDataTable>
+  <div class="au-u-margin-bottom">
+    <AuDataTable
+      @content={{this.linkedTemplates.value}}
+      @isLoading={{this.linkedTemplates.isLoading}}
+      @noDataMessage={{t
+        "snippets.edit-snippet-list.connected-documents.templates-table.no-data"
+      }}
+      as |s|
+    >
+      <s.content as |c|>
+        <c.header>
+          <th>{{t
+              "snippets.edit-snippet-list.connected-documents.templates-table.columns.template"
+            }}</th>
+        </c.header>
+        <c.body as |template|>
+          <td>
+            <AuLink
+              @skin="primary"
+              @route="template-management.edit"
+              @model={{template.id}}
+            >
+              {{template.currentVersion.title}}
+            </AuLink>
+          </td>
+        </c.body>
+      </s.content>
+    </AuDataTable>
+  </div>
+  <div class="au-u-margin-bottom">
+    <AuDataTable
+      @content={{this.linkedSnippets.value}}
+      @isLoading={{this.linkedSnippets.isLoading}}
+      @noDataMessage={{t
+        "snippets.edit-snippet-list.connected-documents.snippets-table.no-data"
+      }}
+      as |s|
+    >
+      <s.content as |c|>
+        <c.header>
+          <th>
+            {{t
+              "snippets.edit-snippet-list.connected-documents.snippets-table.columns.snippet"
+            }}
+          </th>
+        </c.header>
+        <c.body as |snippet|>
+          <td>
+            <AuLink
+              @skin="primary"
+              @route="snippet-management.edit.edit-snippet"
+              @models={{array snippet.snippetList.id snippet.id}}
+            >
+              {{snippet.currentVersion.title}}
+            </AuLink>
+          </td>
+        </c.body>
+      </s.content>
+    </AuDataTable>
+  </div>
 </div>
 <AuModal
   @title={{t "utility.confirmation.body"}}

--- a/app/components/snippet-list-form.js
+++ b/app/components/snippet-list-form.js
@@ -41,6 +41,36 @@ export default class SnippetListForm extends Component {
     return snippets.slice();
   });
 
+  linkedTemplates = trackedFunction(this, async () => {
+    return this.store.countAndFetchAll('document-container', {
+      include: ['current-version'].join(','),
+      filter: {
+        'linked-snippet-lists': {
+          ':id:': this.snippetList.id,
+        },
+      },
+      fields: {
+        'editor-documents': ['title'].join(','),
+      },
+      sort: ':no-case:current-version.title',
+    });
+  });
+
+  linkedSnippets = trackedFunction(this, async () => {
+    return this.store.countAndFetchAll('snippet', {
+      include: ['current-version'].join(','),
+      filter: {
+        'linked-snippet-lists': {
+          ':id:': this.snippetList.id,
+        },
+      },
+      fields: {
+        'snippet-versions': ['title'].join(','),
+      },
+      sort: ':no-case:current-version.title',
+    });
+  });
+
   @action
   async reorderSnippets(newSnippets) {
     this.snippets = newSnippets;

--- a/app/controllers/snippet-management/edit/edit-snippet.js
+++ b/app/controllers/snippet-management/edit/edit-snippet.js
@@ -120,6 +120,7 @@ import {
 import { saveCollatedImportedResources } from '../../../utils/imported-resources';
 import { variableAutofillerPlugin } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/variable-plugin/plugins/autofiller';
 import { IVGR_TAGS, RMW_TAGS } from '../../../utils/constants';
+import { extractSnippetListUris } from '../../../utils/extract-snippet-lists';
 
 export default class SnippetManagementEditSnippetController extends Controller {
   AttributeEditor = AttributeEditor;
@@ -396,6 +397,11 @@ export default class SnippetManagementEditSnippetController extends Controller {
     await Promise.all([currentVersion.save(), newVersion.save()]);
     snippet.currentVersion = newVersion;
     snippet.updatedOn = now;
+    const snippetListUris = extractSnippetListUris(html);
+    const snippetListObjects = await Promise.all(
+      snippetListUris.map((uri) => this.store.findByUri('snippet-list', uri)),
+    );
+    snippet.linkedSnippetLists = snippetListObjects;
     await snippet.save();
     await this.updateImportedResourcesOnList.perform();
   });

--- a/app/controllers/template-management/edit.js
+++ b/app/controllers/template-management/edit.js
@@ -128,6 +128,7 @@ import {
   osloLocationView,
 } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/location-plugin/node';
 import { variableAutofillerPlugin } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/variable-plugin/plugins/autofiller';
+import { extractSnippetListUris } from '../../utils/extract-snippet-lists';
 
 const SNIPPET_LISTS_IDS_DOCUMENT_ATTRIBUTE = 'data-snippet-list-ids';
 const GEMEENTE_CLASSIFICATION_URI =
@@ -494,6 +495,12 @@ export default class TemplateManagementEditController extends Controller {
 
     const documentContainer = this.model.documentContainer;
     documentContainer.currentVersion = editorDocument;
+
+    const snippetListUris = extractSnippetListUris(html);
+    const snippetListObjects = await Promise.all(
+      snippetListUris.map((uri) => this.store.findByUri('snippet-list', uri)),
+    );
+    documentContainer.linkedSnippetLists = snippetListObjects;
     await documentContainer.save();
     this._editorDocument = editorDocument;
   });

--- a/app/models/document-container.js
+++ b/app/models/document-container.js
@@ -1,13 +1,14 @@
 import Model, { belongsTo, hasMany } from '@ember-data/model';
 
 export default class DocumentContainerModel extends Model {
-  @hasMany('editor-document', { inverse: 'documentContainer', async: true })
-  revisions;
   @belongsTo('editor-document', { inverse: null, async: true }) currentVersion;
   @belongsTo('editor-document-folder', { inverse: null, async: true }) folder;
   @belongsTo('administrative-unit', { inverse: null, async: true }) publisher;
-  @hasMany('snippet-list', { inverse: 'templates', async: true })
-  snippetLists;
+
+  @hasMany('editor-document', { inverse: 'documentContainer', async: true })
+  revisions;
+  @hasMany('snippet-list', { inverse: null, async: true })
+  linkedSnippetLists;
 
   get templateTypeId() {
     return this.folder.then((folder) => folder?.id);

--- a/app/models/snippet-list.js
+++ b/app/models/snippet-list.js
@@ -6,10 +6,6 @@ export default class SnippetList extends Model {
   @attr importedResources;
 
   @hasMany('snippet', { async: true, inverse: 'snippetList' }) snippets;
-  @hasMany('document-container', {
-    async: true,
-    inverse: 'snippetLists',
-  })
-  templates;
+
   @belongsTo('administrative-unit', { async: true, inverse: null }) publisher;
 }

--- a/app/models/snippet.js
+++ b/app/models/snippet.js
@@ -8,5 +8,7 @@ export default class SnippetModel extends Model {
 
   @belongsTo('snippet-version', { inverse: null, async: true }) currentVersion;
   @belongsTo('snippet-list', { inverse: 'snippets', async: true }) snippetList;
+
   @hasMany('snippet-version', { inverse: 'snippet', async: true }) revisions;
+  @hasMany('snippet-list', { inverse: null, async: true }) linkedSnippetLists;
 }

--- a/app/routes/snippet-management/edit.js
+++ b/app/routes/snippet-management/edit.js
@@ -6,7 +6,7 @@ export default class SnippetManagementEditRoute extends Route {
 
   async model(params) {
     return await this.store.findRecord('snippet-list', params.id, {
-      include: 'snippets,templates,templates.current-version',
+      include: 'snippets',
     });
   }
 

--- a/app/services/store.js
+++ b/app/services/store.js
@@ -48,4 +48,15 @@ export default class extends Store {
       },
     });
   }
+
+  async findByUri(modelName, uri) {
+    const query = {
+      filter: {
+        ':uri:': uri,
+      },
+    };
+
+    const results = await this.query(modelName, query);
+    return results[0];
+  }
 }

--- a/app/utils/extract-snippet-lists.js
+++ b/app/utils/extract-snippet-lists.js
@@ -15,14 +15,14 @@ function extractTriplesFromDocument(html) {
   const node = document.createElement('body');
   node.innerHTML = html;
   const contexts = analyse(node).map((c) => c.context);
-  return cleanupTriples(contexts.flat());
+  return dedupTriples(contexts.flat());
 }
 
-function cleanupTriples(triples) {
-  const cleantriples = {};
+function dedupTriples(triples) {
+  const dedupedTriples = {};
   for (const triple of triples) {
     const hash = JSON.stringify(triple);
-    cleantriples[hash] = triple;
+    dedupedTriples[hash] = triple;
   }
-  return Object.keys(cleantriples).map((k) => cleantriples[k]);
+  return Object.values(dedupedTriples);
 }

--- a/app/utils/extract-snippet-lists.js
+++ b/app/utils/extract-snippet-lists.js
@@ -1,0 +1,28 @@
+import { analyse } from '@lblod/marawa/rdfa-context-scanner';
+
+export function extractSnippetListUris(html) {
+  const triples = extractTriplesFromDocument(html);
+  const snippetListUris = triples
+    .filter(
+      (triple) =>
+        triple.predicate === 'https://say.data.gift/ns/allowedSnippetList',
+    )
+    .map((triple) => triple.object);
+  return [...new Set(snippetListUris)];
+}
+
+function extractTriplesFromDocument(html) {
+  const node = document.createElement('body');
+  node.innerHTML = html;
+  const contexts = analyse(node).map((c) => c.context);
+  return cleanupTriples(contexts.flat());
+}
+
+function cleanupTriples(triples) {
+  const cleantriples = {};
+  for (const triple of triples) {
+    const hash = JSON.stringify(triple);
+    cleantriples[hash] = triple;
+  }
+  return Object.keys(cleantriples).map((k) => cleantriples[k]);
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "license": "MIT",
       "dependencies": {
         "@babel/plugin-proposal-decorators": "^7.22.10",
+        "@lblod/marawa": "^0.8.0-beta.6",
         "@triply/yasgui": "^4.2.26",
         "date-fns": "^2.30.0",
         "ember-cli-string-helpers": "^6.1.0",
@@ -12424,7 +12425,7 @@
       "version": "0.8.0-beta.6",
       "resolved": "https://registry.npmjs.org/@lblod/marawa/-/marawa-0.8.0-beta.6.tgz",
       "integrity": "sha512-BW3yCpeQlk9EPnQAEQnM9uViA8RC5DkuoiaPJzbuhMcLvKHfI4cjc6dTg9i8qAijbL/xObmQ/Aexko2Xcj9ktw==",
-      "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@rdfjs/data-model": "^1.2.0",
         "@rdfjs/dataset": "^1.1.0"
@@ -12434,7 +12435,6 @@
       "version": "1.3.4",
       "resolved": "https://registry.npmjs.org/@rdfjs/data-model/-/data-model-1.3.4.tgz",
       "integrity": "sha512-iKzNcKvJotgbFDdti7GTQDCYmL7GsGldkYStiP0K8EYtN7deJu5t7U11rKTz+nR7RtesUggT+lriZ7BakFv8QQ==",
-      "dev": true,
       "dependencies": {
         "@rdfjs/types": ">=1.0.1"
       },
@@ -12446,7 +12446,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@rdfjs/dataset/-/dataset-1.1.1.tgz",
       "integrity": "sha512-BNwCSvG0cz0srsG5esq6CQKJc1m8g/M0DZpLuiEp0MMpfwguXX7VeS8TCg4UUG3DV/DqEvhy83ZKSEjdsYseeA==",
-      "dev": true,
       "dependencies": {
         "@rdfjs/data-model": "^1.2.0"
       },
@@ -13714,7 +13713,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@rdfjs/types/-/types-1.1.0.tgz",
       "integrity": "sha512-5zm8bN2/CC634dTcn/0AhTRLaQRjXDZs3QfcAsQKNturHT7XVWcKy/8p3P5gXl+YkZTAmy7T5M/LyiT/jbkENw==",
-      "dev": true,
       "dependencies": {
         "@types/node": "*"
       }

--- a/package.json
+++ b/package.json
@@ -122,6 +122,7 @@
   },
   "dependencies": {
     "@babel/plugin-proposal-decorators": "^7.22.10",
+    "@lblod/marawa": "^0.8.0-beta.6",
     "@triply/yasgui": "^4.2.26",
     "date-fns": "^2.30.0",
     "ember-cli-string-helpers": "^6.1.0",

--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -169,6 +169,16 @@ snippets:
         snippet: Snippet
       no-data: No snippets were found
       loading-error: An error occurred while trying to load snippets
+    connected-documents:
+      heading: Available In
+      templates-table:
+        columns:
+          template: Template
+        no-data: No templates connected to this snippet list
+      snippets-table:
+        columns:
+          snippet: Snippet
+        no-data: No snippets connected to this snippet list
     connected-templates:
       heading: Available in
       table:

--- a/translations/nl-BE.yaml
+++ b/translations/nl-BE.yaml
@@ -169,12 +169,16 @@ snippets:
         snippet: Fragment
       no-data: Geen fragmenten gevonden
       loading-error: Er is een fout opgetreden tijdens het laden van fragmenten
-    connected-templates:
+    connected-documents:
       heading: Beschikbaar in
-      table:
+      templates-table:
         columns:
           template: Sjabloon
         no-data: Geen sjablonen gekoppeld aan deze fragmentlijst
+      snippets-table:
+        columns:
+          snippet: Fragment
+        no-data: Geen fragmenten gekoppeld aan deze fragmentlijst
     snippet-deletion:
       confirm: Bevestig om fragment <strong>{name}</strong> te verwijderen
       action:


### PR DESCRIPTION
## Overview
This PR fixes and extends the functionality of displaying the connected documents (templates and snippets) when editing a snippet-list:
- `SnippetList` model: remove unnecessary `templates` relationship
- `DocumentContainer` model: rename `snippetLists` relationship to `linkedSnippetLists`
- `Snippet` model: add `linkedSnippetLists` relationship
- Extend `snippet-list` edit page to include both connected templates *and* connected snippets
- Add `@lblod/marawa` dependency to allow for RDFa document parsing
- Ensure the connected snippet-lists are extracted and stored on saving templates/snippets

##### connected issues and PRs:
[GN-5055](https://binnenland.atlassian.net/browse/GN-5055)
Requires https://github.com/lblod/app-reglementaire-bijlage/pull/85


### Setup
Ensure you're running the RB stack locally, with the following PR applied: https://github.com/lblod/app-reglementaire-bijlage/pull/85

### How to test/reproduce
- Start the app
- Create a snippet list (`snippet-list-1`) with some snippets
- Create a second snippet list (`snippet-list-2`) with some snippets
- Create a template (`template-1`)
- Configure a snippet placeholder in `template-1` with both `snippet-list-1` and `snippet-list-2` configured
- Open the edit pages for either `snippet-list-1` or `snippet-list-2`
- `template-1` should be listed as a 'Connected template'
- Configure one of the snippet-lists in another snippet
- Ensure that snippet now shows up as 'connected'
- The links to the connected templates and snippets should work as expected

### Checks PR readiness
- [x] UI: works on smaller screen sizes
- [x] UI: feedback for any loading/error states
- [x] Check cancel/go-back flows
- [x] Check database state correct when deleting/updating (especially regarding relationships)
- [x] changelog
- [x] npm lint
- [x] no new deprecations