### PR TITLE
Feat/regenerate variable uris

### DIFF
--- a/.changeset/warm-months-rest.md
+++ b/.changeset/warm-months-rest.md
@@ -1,0 +1,5 @@
+---
+"frontend-reglementaire-bijlage": minor
+---
+
+Add a card to regenerate variable uris

--- a/app/components/regenerate-variable-uris.hbs
+++ b/app/components/regenerate-variable-uris.hbs
@@ -1,0 +1,22 @@
+<AuCard
+  @flex={{true}}
+  @divided={{true}}
+  @isOpenInitially={{true}}
+  @expandable={{true}}
+  @shadow={{true}}
+  @size='small'
+  as |c|
+>
+  <c.header>
+    <AuHeading @level='3' @skin='6'>
+      {{t 'regenerate-variable-uris.modal-title'}}
+    </AuHeading>
+  </c.header>
+  <c.content>
+  <AuButton
+      {{on 'click' this.regenerate}}
+    >
+      {{t 'regenerate-variable-uris.button'}}
+    </AuButton>
+  </c.content>
+</AuCard>

--- a/app/components/regenerate-variable-uris.js
+++ b/app/components/regenerate-variable-uris.js
@@ -1,0 +1,53 @@
+import Component from '@glimmer/component';
+import { action } from '@ember/object';
+import { getOutgoingTriple } from '@lblod/ember-rdfa-editor-lblod-plugins/utils/namespace';
+import { EXT } from '@lblod/ember-rdfa-editor-lblod-plugins/utils/constants';
+import { v4 as uuidv4 } from 'uuid';
+import { sayDataFactory } from '@lblod/ember-rdfa-editor/core/say-data-factory';
+
+const VARIABLE_TYPES = [
+  'address',
+  'date',
+  'text_variable',
+  'oslo_location',
+  'person_variable',
+  'autofilled_variable',
+  'number',
+  'codelist',
+];
+export default class RegenerateVariableUrisComponent extends Component {
+  get controller() {
+    return this.args.controller;
+  }
+
+  @action
+  regenerate() {
+    const doc = this.controller.mainEditorState.doc;
+    const nodesReversed = [];
+    doc.descendants((node, pos) => {
+      if (VARIABLE_TYPES.includes(node.type.name)) {
+        nodesReversed.unshift({ node, pos });
+      }
+    });
+    for (let { node, pos } of nodesReversed) {
+      this.recreateUris(node, pos);
+    }
+  }
+  recreateUris(node, pos) {
+    const newAttrs = { ...node.attrs };
+    console.log();
+    if (newAttrs.subject) {
+      newAttrs.subject = `http://data.lblod.info/mappings/--ref-uuid4-${uuidv4()}`;
+    }
+    const instanceTriple = getOutgoingTriple(newAttrs, EXT('instance'));
+    if (instanceTriple) {
+      let recreatedUri = `http://data.lblod.info/variables/--ref-uuid4-${uuidv4()}`;
+      instanceTriple.object = sayDataFactory.namedNode(recreatedUri);
+    }
+    this.controller.withTransaction((tr) => {
+      tr.setNodeAttribute(pos, 'subject', newAttrs.subject);
+      tr.setNodeAttribute(pos, 'properties', newAttrs.properties);
+      return tr;
+    });
+  }
+}

--- a/app/components/regenerate-variable-uris.js
+++ b/app/components/regenerate-variable-uris.js
@@ -35,7 +35,6 @@ export default class RegenerateVariableUrisComponent extends Component {
   }
   recreateUris(node, pos) {
     const newAttrs = { ...node.attrs };
-    console.log();
     if (newAttrs.subject) {
       newAttrs.subject = `http://data.lblod.info/mappings/--ref-uuid4-${uuidv4()}`;
     }

--- a/app/templates/snippet-management/edit/edit-snippet.hbs
+++ b/app/templates/snippet-management/edit/edit-snippet.hbs
@@ -143,6 +143,7 @@
               @options={{this.config.structures}}
             />
           </Sidebar.Collapsible>
+          <RegenerateVariableUris @controller={{this.editor}} />
           <this.StructureControlCard @controller={{this.editor}} />
           <MandateeTablePlugin::Configure
             @controller={{this.editor}}

--- a/app/templates/template-management/edit.hbs
+++ b/app/templates/template-management/edit.hbs
@@ -117,7 +117,7 @@
     <:aside>
       {{#if this.editor}}
         <Sidebar as |Sidebar|>
-
+          <RegenerateVariableUris @controller={{this.editor}} />
           <Sidebar.Collapsible
             @title={{t "snippet-edit.sidebar.general-nodes"}}
             @expandedInitially={{false}}
@@ -202,6 +202,7 @@
             />
             <this.DebugInfo @node={{this.activeNode}} />
           {{/if}}
+
           <this.StructureControl @controller={{this.editor}} />
           <MandateeTablePlugin::Configure
             @controller={{this.editor}}
@@ -228,6 +229,7 @@
           />
           <VariablePlugin::Autofilled::Edit @controller={{this.editor}} />
           <TemplateCommentsPlugin::EditCard @controller={{this.editor}} />
+
           {{! VariablePlugin::TemplateVariableCard is not added on purpose
           as an RB-document creator should not be able to set a "default" codelist option.}}
         </Sidebar>

--- a/app/templates/template-management/edit.hbs
+++ b/app/templates/template-management/edit.hbs
@@ -117,7 +117,7 @@
     <:aside>
       {{#if this.editor}}
         <Sidebar as |Sidebar|>
-          <RegenerateVariableUris @controller={{this.editor}} />
+
           <Sidebar.Collapsible
             @title={{t "snippet-edit.sidebar.general-nodes"}}
             @expandedInitially={{false}}
@@ -190,6 +190,7 @@
               />
             </Sidebar.Collapsible>
           {{/unless}}
+          <RegenerateVariableUris @controller={{this.editor}} />
           <Plugins::Link::LinkEditor @controller={{this.editor}} />
           <this.RdfaEditor
             @node={{this.activeNode}}

--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -22,8 +22,8 @@ codelist:
     options: "Options"
     id: Id
     types:
-      singleSelect: 'Single select'
-      multiSelect: 'Multi select'
+      singleSelect: "Single select"
+      multiSelect: "Multi select"
   options:
     label: Label
     label-explanation: Optional shorter description
@@ -206,3 +206,7 @@ editor:
 
 search-form:
   aria-label: Search
+
+regenerate-variable-uris:
+  modal-title: Regenerate variable URIs
+  button: Regenerate

--- a/translations/nl-BE.yaml
+++ b/translations/nl-BE.yaml
@@ -22,8 +22,8 @@ codelist:
     options: "Items"
     id: Id
     types:
-      singleSelect: 'Single select'
-      multiSelect: 'Multi select'
+      singleSelect: "Single select"
+      multiSelect: "Multi select"
   options:
     label: Label
     label-explanation: Optionele kortere weergave
@@ -102,7 +102,7 @@ template-management:
     save: Opslaan
     cancel: Terug
   remove-modal:
-    title:  Weet u zeker dat u dit sjabloon wilt verwijderen?
+    title: Weet u zeker dat u dit sjabloon wilt verwijderen?
     remove: Sjabloon verwijderen
     cancel: Terug
 template-edit:
@@ -206,3 +206,7 @@ editor:
 
 search-form:
   aria-label: Zoek
+
+regenerate-variable-uris:
+  modal-title: Variabele URI's opnieuw genereren
+  button: Regenereer


### PR DESCRIPTION
## Overview
Added a card to regenerate variable uris

##### connected issues and PRs:
GN-5232


### Setup
None

### How to test/reproduce
Go to an old document where you have old variabels without the template uri, click on the button, and observe that now you have template uris on those variables

### Challenges/uncertainties
None



### Checks PR readiness
- [x] UI: works on smaller screen sizes
- [x] UI: feedback for any loading/error states
- [x] Check cancel/go-back flows
- [x] Check database state correct when deleting/updating (especially regarding relationships)
- [x] changelog
- [x] npm lint
- [x] no new deprecations