### PR TITLE
Fix http error when opening templates

### DIFF
--- a/.changeset/purple-cameras-change.md
+++ b/.changeset/purple-cameras-change.md
@@ -1,0 +1,5 @@
+---
+"frontend-reglementaire-bijlage": patch
+---
+
+`TemplateManagementEditRoute`: remove erroneous `snippet-lists` include from `document-container` query

--- a/app/controllers/template-management/edit.js
+++ b/app/controllers/template-management/edit.js
@@ -521,25 +521,4 @@ export default class TemplateManagementEditController extends Controller {
     );
     this.assignedSnippetListsIds = snippetIds;
   }
-
-  setDocumentContainerSnippetLists = task(async (snippetIds) => {
-    if (!snippetIds || !snippetIds.length) {
-      this.documentSnippetListIds = [];
-      this.model.documentContainer.snippetLists.setObjects([]);
-
-      return this.save.perform();
-    }
-
-    const snippetLists = await this.store.query('snippet-list', {
-      filter: {
-        ':id:': snippetIds.join(','),
-      },
-      include: 'snippets',
-    });
-
-    this.documentSnippetListIds = snippetIds;
-    this.model.documentContainer.snippetLists.setObjects(snippetLists);
-
-    return this.save.perform();
-  });
 }

--- a/app/routes/template-management/edit.js
+++ b/app/routes/template-management/edit.js
@@ -14,7 +14,7 @@ export default class TemplateManagementEditRoute extends Route {
       'document-container',
       params.id,
       {
-        include: 'current-version,snippet-lists,snippet-lists.snippets,folder',
+        include: 'current-version,folder',
       },
     );
     return hash({


### PR DESCRIPTION
## Overview
This PR includes two adjustments/fixes:
- `TemplateManagementEditRoute`: drop the `snippet-lists` relationship from the include in the `document-container` query
- `TemplateManagementEditController`: remove obsolete/unused method

##### connected issues and PRs:
https://github.com/lblod/frontend-reglementaire-bijlage/pull/299


### Setup
None

### How to test/reproduce
- Start the frontend
- Open a template
- No HTTP error should occur, the template should open as usual