### PR TITLE
Functionality for unpublishing templates

### DIFF
--- a/.changeset/shy-ravens-turn.md
+++ b/.changeset/shy-ravens-turn.md
@@ -1,0 +1,5 @@
+---
+"frontend-reglementaire-bijlage": minor
+---
+
+Add functionality to unpublish templates

--- a/app/components/app-chrome.hbs
+++ b/app/components/app-chrome.hbs
@@ -42,12 +42,6 @@
         {{/if}}
       </Group>
       <Group>
-        {{#if @isPublished}}
-        <AuPill @skin="success" @icon="eye">
-          {{t "utility.available"}}
-        </AuPill>
-        {{/if}}
-
         {{yield to="leadingButtons"}}
         {{#if @save}}
         <AuButton {{on "click" @save.action}} @disabled={{@save.isRunning}}>{{t "utility.save"}}</AuButton>

--- a/app/components/app-chrome.js
+++ b/app/components/app-chrome.js
@@ -17,7 +17,6 @@ import SnippetVersionModel from '../models/snippet-version';
  * @property {boolean|undefined} readonly
  * @property {string|undefined} templateTypeId
  * @property {boolean|undefined} dirty
- * @property {boolean|undefined} isPublished
  * @property {PublishSaveAction|undefined} save
  * @property {PublishSaveAction|undefined} publish
  */

--- a/app/components/confirm-modal.hbs
+++ b/app/components/confirm-modal.hbs
@@ -1,0 +1,26 @@
+<AuModal
+  @title={{or @title (t 'utility.confirmation.body')}}
+  @modalOpen={{@modalOpen}}
+  @closeModal={{this.onCancel}}
+  as |Modal|
+>
+  {{#if @message}}
+    <Modal.Body>
+      <p>{{@message}}</p>
+    </Modal.Body>
+  {{/if}}
+  <Modal.Footer>
+    <AuButtonGroup>
+      <AuButton
+        @skin='primary'
+        @alert={{@isAlert}}
+        {{on 'click' this.onConfirm}}
+      >
+        {{or @confirmMessage (t 'utility.confirm')}}
+      </AuButton>
+      <AuButton @skin='secondary' {{on 'click' this.onCancel}}>
+        {{t 'utility.cancel'}}
+      </AuButton>
+    </AuButtonGroup>
+  </Modal.Footer>
+</AuModal>

--- a/app/components/confirm-modal.js
+++ b/app/components/confirm-modal.js
@@ -1,0 +1,31 @@
+import Component from '@glimmer/component';
+import { action } from '@ember/object';
+
+/**
+ * A generic 'confirmation' modal to avoid copy-pasting boilerplate and to keep a consistent style.
+ * @title the title to give for the modal
+ * @message (optional) the message to show in the modal
+ * @confirmMessage (optional) the text to show in the confirm button
+ * @isAlert (optional) should the confirmation button be styled as an 'alert'
+ * @modalOpen boolean flag setting the open state of the modal
+ * @closeModal callback to trigger closing of the modal
+ * @onConfirm (optional) hook when confirmation is clicked
+ * @onCancel (optional) hook when cancellation is clicked or modal is closed
+ */
+export default class ConfirmModelComponent extends Component {
+  @action
+  onConfirm() {
+    if (this.args.onConfirm) {
+      this.args.onConfirm();
+    }
+    this.args.closeModal();
+  }
+
+  @action
+  onCancel() {
+    if (this.args.onCancel) {
+      this.args.onCancel();
+    }
+    this.args.closeModal();
+  }
+}

--- a/app/components/confirm-route-leave.hbs
+++ b/app/components/confirm-route-leave.hbs
@@ -1,19 +1,10 @@
-<AuModal
+<ConfirmModal
   @title={{t 'utility.confirmation.body'}}
+  @message={{or @message (t 'utility.confirm-leave-without-saving')}}
+  @confirmMessage={{or @confirmMessage (t 'utility.discard-changes')}}
+  @isAlert={{true}}
   @modalOpen={{and this.showConfirmModal @enabled}}
-  @closeModal={{this.onCancel}} as |Modal|
->
-  <Modal.Body>
-    <p>
-      {{or @message (t 'utility.confirm-leave-without-saving')}}
-    </p>
-  </Modal.Body>
-  <Modal.Footer>
-    <AuButton @alert={{true}} {{on 'click' this.onConfirm}}>
-      {{or @confirmMessage (t 'utility.discard-changes')}}
-    </AuButton>
-    <AuButton @skin='secondary' {{on 'click' this.onCancel}}>
-      {{t 'utility.cancel'}}
-    </AuButton>
-  </Modal.Footer>
-</AuModal>
+  @closeModal={{this.onCancel}}
+  @onConfirm={{this.onConfirm}}
+  @onCancel={{this.onCancel}}
+/>

--- a/app/controllers/template-management/edit.js
+++ b/app/controllers/template-management/edit.js
@@ -3,9 +3,8 @@ import { action } from '@ember/object';
 import { task } from 'ember-concurrency';
 import { service } from '@ember/service';
 import { tracked } from 'tracked-built-ins';
-import { trackedFunction } from 'reactiveweb/function';
-import { Schema } from '@lblod/ember-rdfa-editor';
 import { v4 as uuid } from 'uuid';
+import { Schema } from '@lblod/ember-rdfa-editor';
 import {
   em,
   strikethrough,
@@ -444,17 +443,6 @@ export default class TemplateManagementEditController extends Controller {
       );
     }
   }
-
-  isPublished = trackedFunction(this, async () => {
-    const publishedTemplate = await this.store.query('template-version', {
-      filter: {
-        'derived-from': {
-          id: this.editorDocument.id,
-        },
-      },
-    })[0];
-    return Boolean(publishedTemplate);
-  });
 
   get dirty() {
     // Since we clear the undo history when saving, this works. If we want to maintain undo history

--- a/app/controllers/template-management/index.js
+++ b/app/controllers/template-management/index.js
@@ -142,9 +142,13 @@ export default class TemplateManagementIndexController extends Controller {
   }
 
   @action
+  closeRemoveTemplateModal() {
+    this.removeTemplateModalIsOpen = false;
+  }
+
+  @action
   cancelRemoveTemplate() {
     this.editorDocument = undefined;
-    this.removeTemplateModalIsOpen = false;
   }
 
   submitRemoveTemplate = task(async () => {
@@ -170,7 +174,6 @@ export default class TemplateManagementIndexController extends Controller {
       }
     }
 
-    this.removeTemplateModalIsOpen = false;
     await this.documentContainer.deleteRecord();
     await this.documentContainer.save();
     this.refresh();

--- a/app/controllers/template-management/index.js
+++ b/app/controllers/template-management/index.js
@@ -87,7 +87,8 @@ export default class TemplateManagementIndexController extends Controller {
       // params you add
       const templateVersion = await publishedTemplate.currentVersion;
       // end of shenanigans
-      let validThrough = templateVersion.validThrough && new Date(templateVersion.validThrough);
+      let validThrough =
+        templateVersion.validThrough && new Date(templateVersion.validThrough);
       if (validThrough && isAfter(validThrough, Date.now())) {
         // Only display as unpublished when it actually is
         validThrough = undefined;

--- a/app/controllers/template-management/index.js
+++ b/app/controllers/template-management/index.js
@@ -3,9 +3,11 @@ import { task } from 'ember-concurrency';
 import { service } from '@ember/service';
 import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
+import { localCopy } from 'tracked-toolbox';
+import isAfter from 'date-fns/isAfter';
 import { isBlank } from '../../utils/strings';
 import { getTemplateType, getTemplateTypes } from '../../utils/template-type';
-import { localCopy } from 'tracked-toolbox';
+
 export default class TemplateManagementIndexController extends Controller {
   @service store;
   @service session;
@@ -85,7 +87,12 @@ export default class TemplateManagementIndexController extends Controller {
       // params you add
       const templateVersion = await publishedTemplate.currentVersion;
       // end of shenanigans
-      return templateVersion.created;
+      let validThrough = templateVersion.validThrough && new Date(templateVersion.validThrough);
+      if (validThrough && isAfter(validThrough, Date.now())) {
+        // Only display as unpublished when it actually is
+        validThrough = undefined;
+      }
+      return { created: templateVersion.created, validThrough };
     } else {
       return;
     }

--- a/app/controllers/template-management/publish.js
+++ b/app/controllers/template-management/publish.js
@@ -14,13 +14,11 @@ export default class TemplateManagementPublishController extends Controller {
   @service intl;
 
   @tracked currentVersion;
-
-  constructor() {
-    super(...arguments);
-  }
+  @tracked currentVersionValidThrough;
 
   fetchPreview = task(async () => {
     this.currentVersion = '';
+    this.currentVersionValidThrough = undefined;
     const currentPublishedTemplate = (
       await this.store.query('template', {
         filter: {
@@ -34,6 +32,9 @@ export default class TemplateManagementPublishController extends Controller {
     if (currentPublishedTemplate) {
       const publishedVersion = await currentPublishedTemplate.currentVersion;
       const response = await fetch(publishedVersion.downloadLink);
+      this.currentVersionValidThrough =
+        publishedVersion.validThrough &&
+        new Date(publishedVersion.validThrough);
       this.currentVersion = await response.text();
     }
   });

--- a/app/routes/template-management/edit.js
+++ b/app/routes/template-management/edit.js
@@ -18,10 +18,23 @@ export default class TemplateManagementEditRoute extends Route {
         reload: true,
       },
     );
+    const templateVersion = await this.store
+      .query('template', {
+        filter: {
+          'derived-from': {
+            id: documentContainer.id,
+          },
+        },
+        // See template-management/index.js for details of this hack
+        avoid_cache: new Date().toISOString(),
+        include: 'current-version',
+      })
+      .then((templates) => templates[0]?.currentVersion);
     return hash({
       documentContainer,
       editorDocument: documentContainer.currentVersion,
       templateTypeId: documentContainer.templateTypeId,
+      templateVersion,
     });
   }
 

--- a/app/templates/template-management/edit.hbs
+++ b/app/templates/template-management/edit.hbs
@@ -20,7 +20,23 @@
     }}
   >
     <:leadingButtons>
-
+      <AuPill
+        @skin={{if this.isPublished "success" "default"}}
+        @icon="eye"
+        @onClickAction={{if this.isPublished this.openConfirmUnpublish}}
+        @actionIcon="cross"
+        @actionText={{t "template-edit.unpublish"}}
+      >
+        {{#if this.isPublished}}
+          {{#if this.model.templateVersion.validThrough}}
+            {{t "template-management.available-until" date=(human-friendly-date this.unpublishDate)}}
+          {{else}}
+            {{t "template-management.available"}}
+          {{/if}}
+        {{else}}
+          {{t "template-management.not-published"}}
+        {{/if}}
+      </AuPill>
       {{#if this.activeNode}}
         <this.SnippetListSelect
           @node={{this.activeNode}}
@@ -238,3 +254,11 @@
   </RdfaEditorContainer>
 {{/if}}
 <ConfirmRouteLeave @enabled={{this.dirty}} />
+<ConfirmModal
+  @title={{t "template-edit.unpublish-confirm"}}
+  @confirmMessage={{t "template-edit.unpublish"}}
+  @isAlert={{true}}
+  @modalOpen={{this.isConfirmUnpublishOpen}}
+  @closeModal={{this.closeConfirmUnpublish}}
+  @onConfirm={{perform this.unpublishTemplate}}
+/>

--- a/app/templates/template-management/edit.hbs
+++ b/app/templates/template-management/edit.hbs
@@ -18,7 +18,6 @@
       action=(perform this.publish)
       isRunning=this.save.isRunning
     }}
-    @isPublished={{this.isPublished.value}}
   >
     <:leadingButtons>
 

--- a/app/templates/template-management/index.hbs
+++ b/app/templates/template-management/index.hbs
@@ -76,7 +76,12 @@
           as |lastPublicationDate|
         }}
           {{#if lastPublicationDate}}
-            {{detailed-date lastPublicationDate}}
+            {{#if lastPublicationDate.validThrough}}
+              <del datetime={{lastPublicationDate.validThrough}}>{{detailed-date
+  lastPublicationDate.created}}</del>
+            {{else}}
+              {{detailed-date lastPublicationDate.created}}
+            {{/if}}
           {{else}}
             {{t "template-management.not-found"}}
           {{/if}}

--- a/app/templates/template-management/index.hbs
+++ b/app/templates/template-management/index.hbs
@@ -149,23 +149,11 @@
     </AuButtonGroup>
   </Modal.Footer>
 </AuModal>
-<AuModal
+<ConfirmModal
   @title={{t "template-management.remove-modal.title"}}
+  @confirmMessage={{t "template-management.remove-modal.remove"}}
   @modalOpen={{this.removeTemplateModalIsOpen}}
-  @closeModal={{this.cancelRemoveTemplate}}
-  as |Modal|
->
-  <Modal.Footer>
-    <AuButtonGroup>
-      <AuButton
-        {{on "click" (perform this.submitRemoveTemplate)}}
-        @skin="primary"
-      >
-        {{t "template-management.remove-modal.remove"}}
-      </AuButton>
-      <AuButton {{on "click" this.cancelRemoveTemplate}} @skin="secondary">
-        {{t "template-management.remove-modal.cancel"}}
-      </AuButton>
-    </AuButtonGroup>
-  </Modal.Footer>
-</AuModal>
+  @closeModal={{this.closeRemoveTemplateModal}}
+  @onConfirm={{perform this.submitRemoveTemplate}}
+  @onCancel={{this.cancelRemoveTemplate}}
+/>

--- a/app/templates/template-management/publish.hbs
+++ b/app/templates/template-management/publish.hbs
@@ -40,7 +40,11 @@
         <AuCard @flex={{true}} as |c|>
           <c.header>
             <AuHeading @level='2' @skin='4'>
-              {{t 'publish-page.publishedversion'}}
+              {{#if this.currentVersionValidThrough}}
+                {{t 'publish-page.published-until' date=(detailed-date this.currentVersionValidThrough)}}
+              {{else}}
+                {{t 'publish-page.publishedversion'}}
+              {{/if}}
             </AuHeading>
           </c.header>
           <c.content>

--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -51,7 +51,6 @@ utility:
   remove-concept: Remove concept
   export-to-html: "Export to HTML"
   to-recycle-bin: "Move to recycle bin"
-  available: Available
   confirmation:
     title: Confirm
     body: Are you sure?
@@ -90,6 +89,9 @@ template-management:
   updated-on: Updated On
   not-found: N/A
   publish-date: Published on
+  not-published: Not published
+  available: Available
+  available-until: Available until {date}
   template-type:
     label: Template type
     decision: Decision
@@ -111,6 +113,8 @@ template-edit:
   saving: Saving
   document-title-placeholder: Enter document title
   insert-title: Insert document title
+  unpublish: Unpublish
+  unpublish-confirm: Are you sure you want to unpublish this template?
 auth:
   acmidm: Log in with acm/idm
   login: Log in

--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -127,6 +127,7 @@ publish-page:
   back: Back to document template
   latestversion: Latest version
   publishedversion: Published version
+  published-until: Version published up until {date}
   publish: Publish
   notification-title: Success
   notification-content: Template successfully published

--- a/translations/nl-BE.yaml
+++ b/translations/nl-BE.yaml
@@ -51,7 +51,6 @@ utility:
   remove-concept: Verwijder concept
   export-to-html: "Exporteer als HTML"
   to-recycle-bin: "Naar prullenmand"
-  available: Beschikbaar
   confirmation:
     title: Bevestigen
     body: Ben je zeker?
@@ -90,6 +89,9 @@ template-management:
   updated-on: Bijgewerkt op
   not-found: n.v.t.
   publish-date: Beschikbaar gemaakt op
+  not-published: Niet uitgegeven
+  available: Beschikbaar
+  available-until: Beschikbaar tot {date}
   template-type:
     label: Sjabloontype
     decision: Besluit
@@ -111,6 +113,8 @@ template-edit:
   saving: Bezig met opslaan
   document-title-placeholder: Geef document-titel op
   insert-title: Document-titel invoegen
+  unpublish: Uitgave ongedaan maken
+  unpublish-confirm: Weet je zeker dat je het uitgeven van deze sjabloon ongedaan wilt maken?
 auth:
   acmidm: Log in met acm/idm
   login: Meld u aan

--- a/translations/nl-BE.yaml
+++ b/translations/nl-BE.yaml
@@ -127,6 +127,7 @@ publish-page:
   back: Terug naar sjabloon
   latestversion: Laatste versie
   publishedversion: Publieke versie
+  published-until: Versie publiek tot {date}
   publish: Maak beschikbaar
   notification-title: Geslaagd
   notification-content: Sjabloon beschikbaar gemaakt


### PR DESCRIPTION
## Overview
Add controls for unpublishing templates and update UI to display details of published status.

##### connected issues and PRs:
PR to fix resources config for `validThrough`: https://github.com/lblod/app-reglementaire-bijlage/pull/86
Jira ticket: https://binnenland.atlassian.net/browse/GN-5192

### Setup
Needs to be pointing to an RB backend with the resources fix. To test, use GN, pointing to this RB.

### How to test/reproduce
You should be able to publish and unpublish templates however you like. Only when published they will be visible in the new agendapoint or regulatory statement modals.

You should also be able to test setting an expiry date by setting the 'validThrough' for a template to be in the future.

### Challenges/uncertainties
The UI was unknown, so I just based my work on what was already there...

### Checks PR readiness
- [ ] UI: works on smaller screen sizes
- [ ] UI: feedback for any loading/error states
- [ ] Check cancel/go-back flows
- [x] Check database state correct when deleting/updating (especially regarding relationships)
- [x] changelog
- [x] npm lint
- [x] no new deprecations