### PR TITLE
Link locations to the surrounding document on insertion

### DIFF
--- a/.changeset/healthy-boxes-jog.md
+++ b/.changeset/healthy-boxes-jog.md
@@ -1,0 +1,5 @@
+---
+"frontend-reglementaire-bijlage": minor
+---
+
+Link locations to the surrounding article or decision on insertion

--- a/app/controllers/snippet-management/edit/edit-snippet.js
+++ b/app/controllers/snippet-management/edit/edit-snippet.js
@@ -118,6 +118,7 @@ import {
   mandatee_table,
   mandateeTableView,
 } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/mandatee-table-plugin/node';
+import { BESLUIT } from '@lblod/ember-rdfa-editor-lblod-plugins/utils/constants';
 import { saveCollatedImportedResources } from '../../../utils/imported-resources';
 import { variableAutofillerPlugin } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/variable-plugin/plugins/autofiller';
 import { IVGR_TAGS, RMW_TAGS } from '../../../utils/constants';
@@ -298,6 +299,7 @@ export default class SnippetManagementEditSnippetController extends Controller {
           'https://publicatie.gelinkt-notuleren.vlaanderen.be/id/plaats/',
         defaultAddressUriRoot:
           'https://publicatie.gelinkt-notuleren.vlaanderen.be/id/adres/',
+        subjectTypesToLinkTo: [BESLUIT('Artikel'), BESLUIT('Besluit')],
       },
       lmb: {
         endpoint: '/vendor-proxy/query',

--- a/app/controllers/template-management/edit.js
+++ b/app/controllers/template-management/edit.js
@@ -128,6 +128,10 @@ import {
   osloLocationView,
 } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/location-plugin/node';
 import { variableAutofillerPlugin } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/variable-plugin/plugins/autofiller';
+import {
+  BESLUIT,
+  SAY,
+} from '@lblod/ember-rdfa-editor-lblod-plugins/utils/constants';
 import { extractSnippetListUris } from '../../utils/extract-snippet-lists';
 
 const SNIPPET_LISTS_IDS_DOCUMENT_ATTRIBUTE = 'data-snippet-list-ids';
@@ -342,6 +346,15 @@ export default class TemplateManagementEditController extends Controller {
           'https://publicatie.gelinkt-notuleren.vlaanderen.be/id/plaats/',
         defaultAddressUriRoot:
           'https://publicatie.gelinkt-notuleren.vlaanderen.be/id/adres/',
+        subjectTypesToLinkTo:
+          this.internalTypeName === 'decision'
+            ? [BESLUIT('Artikel'), BESLUIT('Besluit')]
+            : [
+                SAY('Article'),
+                SAY('Subsection'),
+                SAY('Section'),
+                SAY('Chapter'),
+              ],
       },
       autofilledVariable: {
         autofilledValues: {},

--- a/package-lock.json
+++ b/package-lock.json
@@ -40,7 +40,7 @@
         "@lblod/ember-environment-banner": "^0.5.0",
         "@lblod/ember-mock-login": "^0.10.0",
         "@lblod/ember-rdfa-editor": "10.9.0",
-        "@lblod/ember-rdfa-editor-lblod-plugins": "^26.0.2",
+        "@lblod/ember-rdfa-editor-lblod-plugins": "26.1.0-dev.23bbb85064dc86744df1e40778809fbb82cbbdb7",
         "@release-it-plugins/lerna-changelog": "^6.0.0",
         "@tsconfig/ember": "^3.0.8",
         "broccoli-asset-rev": "^3.0.0",
@@ -12121,10 +12121,11 @@
       }
     },
     "node_modules/@lblod/ember-rdfa-editor-lblod-plugins": {
-      "version": "26.0.2",
-      "resolved": "https://registry.npmjs.org/@lblod/ember-rdfa-editor-lblod-plugins/-/ember-rdfa-editor-lblod-plugins-26.0.2.tgz",
-      "integrity": "sha512-cGq9/dH8ZHcbf0p6zdwAETE/eYwG1Wk4OmXro1tufWJNzUwIotUxRPsrmVYMQ//cVkx9b3FEspUrom+pdH69gw==",
+      "version": "26.1.0-dev.23bbb85064dc86744df1e40778809fbb82cbbdb7",
+      "resolved": "https://registry.npmjs.org/@lblod/ember-rdfa-editor-lblod-plugins/-/ember-rdfa-editor-lblod-plugins-26.1.0-dev.23bbb85064dc86744df1e40778809fbb82cbbdb7.tgz",
+      "integrity": "sha512-l/isOAUhWIdRP5l8PdEfJ+JAwldRWh1EaZydHiLwyJX57BmJEk+8YIs/HMTpHDt/t8/4LUi1SoFSeEGFR7f/fQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@codemirror/lang-html": "^6.4.9",
         "@codemirror/state": "^6.4.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -40,7 +40,7 @@
         "@lblod/ember-environment-banner": "^0.5.0",
         "@lblod/ember-mock-login": "^0.10.0",
         "@lblod/ember-rdfa-editor": "10.9.1",
-        "@lblod/ember-rdfa-editor-lblod-plugins": "26.1.0-dev.23bbb85064dc86744df1e40778809fbb82cbbdb7",
+        "@lblod/ember-rdfa-editor-lblod-plugins": "26.2.0",
         "@release-it-plugins/lerna-changelog": "^6.0.0",
         "@tsconfig/ember": "^3.0.8",
         "broccoli-asset-rev": "^3.0.0",
@@ -12121,9 +12121,9 @@
       }
     },
     "node_modules/@lblod/ember-rdfa-editor-lblod-plugins": {
-      "version": "26.1.0-dev.23bbb85064dc86744df1e40778809fbb82cbbdb7",
-      "resolved": "https://registry.npmjs.org/@lblod/ember-rdfa-editor-lblod-plugins/-/ember-rdfa-editor-lblod-plugins-26.1.0-dev.23bbb85064dc86744df1e40778809fbb82cbbdb7.tgz",
-      "integrity": "sha512-l/isOAUhWIdRP5l8PdEfJ+JAwldRWh1EaZydHiLwyJX57BmJEk+8YIs/HMTpHDt/t8/4LUi1SoFSeEGFR7f/fQ==",
+      "version": "26.2.0",
+      "resolved": "https://registry.npmjs.org/@lblod/ember-rdfa-editor-lblod-plugins/-/ember-rdfa-editor-lblod-plugins-26.2.0.tgz",
+      "integrity": "sha512-DYjmKQeDaXYFeNh8dx8+rGj0yW+zS1gfuTuxtY5++zLRAWKmwQKt+uTxCl6l7W9l8XUuSBlykwpf92hswmrVkQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "@lblod/ember-environment-banner": "^0.5.0",
     "@lblod/ember-mock-login": "^0.10.0",
     "@lblod/ember-rdfa-editor": "10.9.0",
-    "@lblod/ember-rdfa-editor-lblod-plugins": "^26.0.2",
+    "@lblod/ember-rdfa-editor-lblod-plugins": "26.1.0-dev.23bbb85064dc86744df1e40778809fbb82cbbdb7",
     "@release-it-plugins/lerna-changelog": "^6.0.0",
     "@tsconfig/ember": "^3.0.8",
     "broccoli-asset-rev": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "@lblod/ember-environment-banner": "^0.5.0",
     "@lblod/ember-mock-login": "^0.10.0",
     "@lblod/ember-rdfa-editor": "10.9.1",
-    "@lblod/ember-rdfa-editor-lblod-plugins": "26.1.0-dev.23bbb85064dc86744df1e40778809fbb82cbbdb7",
+    "@lblod/ember-rdfa-editor-lblod-plugins": "26.2.0",
     "@release-it-plugins/lerna-changelog": "^6.0.0",
     "@tsconfig/ember": "^3.0.8",
     "broccoli-asset-rev": "^3.0.0",


### PR DESCRIPTION
### Overview
Just a matter of adding the new configuration.

A draft until plugins PR is merged.

##### connected issues and PRs:
Plugins PR: https://github.com/lblod/ember-rdfa-editor-lblod-plugins/pull/517
GN PR: https://github.com/lblod/frontend-gelinkt-notuleren/pull/794
Jira ticket: https://binnenland.atlassian.net/browse/GN-5022

### Setup
N/A

### How to test/reproduce
Same as plugins PR, for templates or snippets. Should handle the type of template correctly.

### Challenges/uncertainties
I wasn't sure if we should do this on RSs, but I made a guess.

### Checks PR readiness
- [ ] UI: works on smaller screen sizes
- [ ] UI: feedback for any loading/error states
- [ ] Check cancel/go-back flows
- [ ] Check database state correct when deleting/updating (especially regarding relationships)
- [x] changelog
- [x] npm lint
- [x] no new deprecations
