### PR TITLE
Slightly rework mu-task handling

### DIFF
--- a/.changeset/sharp-starfishes-yawn.md
+++ b/.changeset/sharp-starfishes-yawn.md
@@ -1,0 +1,6 @@
+---
+"frontend-reglementaire-bijlage": patch
+---
+
+- Fetch tasks using `ember-data` and `mu-cl-resources` endpoint
+- Use generic task statuses

--- a/app/models/task.js
+++ b/app/models/task.js
@@ -1,0 +1,6 @@
+import Model, { attr } from '@ember-data/model';
+
+export default class TaskModel extends Model {
+  @attr uri;
+  @attr status;
+}

--- a/app/models/task.js
+++ b/app/models/task.js
@@ -3,4 +3,7 @@ import Model, { attr } from '@ember-data/model';
 export default class TaskModel extends Model {
   @attr uri;
   @attr status;
+  @attr operation;
+  @attr created;
+  @attr modified;
 }

--- a/app/utils/constants.js
+++ b/app/utils/constants.js
@@ -25,3 +25,11 @@ export const RMW_TAGS = /** @type {const} */ ([
   'IVRMW2-LBM-4-geloofsbrieven-leden',
   'IVRMW2-LBM-5-eed-leden',
 ]);
+
+export const JOB_STATUSES = {
+  scheduled: 'http://redpencil.data.gift/id/concept/JobStatus/scheduled',
+  busy: 'http://redpencil.data.gift/id/concept/JobStatus/busy',
+  success: 'http://redpencil.data.gift/id/concept/JobStatus/success',
+  failed: 'http://redpencil.data.gift/id/concept/JobStatus/failed',
+  canceled: 'http://redpencil.data.gift/id/concept/JobStatus/canceled',
+};


### PR DESCRIPTION
## Overview
This PR includes two internal changes:
- Usage of more generic task 'status' URIs
- Use ember-data + mu-cl-resources to fetch tasks using JSON:API

##### connected issues and PRs:
https://github.com/lblod/reglement-publish-service/pull/19
https://github.com/lblod/app-reglementaire-bijlage/pull/88

### Setup
Check-out https://github.com/lblod/app-reglementaire-bijlage/pull/88 for instructions


### How to test/reproduce
Check-out https://github.com/lblod/app-reglementaire-bijlage/pull/88 for instructions



### Checks PR readiness
- [x] UI: works on smaller screen sizes
- [x] UI: feedback for any loading/error states
- [x] Check cancel/go-back flows
- [x] Check database state correct when deleting/updating (especially regarding relationships)
- [x] changelog
- [x] npm lint
- [x] no new deprecations