### PR TITLE
Link locations to the surrounding document on insertion

### DIFF
--- a/.changeset/sharp-llamas-decide.md
+++ b/.changeset/sharp-llamas-decide.md
@@ -1,0 +1,5 @@
+---
+"frontend-reglementaire-bijlage": minor
+---
+
+Remove deprecated address variable and update to @lblod/ember-rdfa-editor-lblod-plugins version with corrected RDFa output

--- a/app/controllers/snippet-management/edit/edit-snippet.js
+++ b/app/controllers/snippet-management/edit/edit-snippet.js
@@ -102,7 +102,6 @@ import TextVariableInsertComponent from '@lblod/ember-rdfa-editor-lblod-plugins/
 import NumberInsertComponent from '@lblod/ember-rdfa-editor-lblod-plugins/components/variable-plugin/number/insert';
 import DateInsertVariableComponent from '@lblod/ember-rdfa-editor-lblod-plugins/components/variable-plugin/date/insert-variable';
 import CodelistInsertComponent from '@lblod/ember-rdfa-editor-lblod-plugins/components/variable-plugin/codelist/insert';
-import VariablePluginAddressInsertVariableComponent from '@lblod/ember-rdfa-editor-lblod-plugins/components/variable-plugin/address/insert-variable';
 import PersonVariableInsertComponent from '@lblod/ember-rdfa-editor-lblod-plugins/components/variable-plugin/person/insert';
 import SnippetInsertRdfaComponent from '@lblod/ember-rdfa-editor-lblod-plugins/components/snippet-plugin/snippet-insert-rdfa';
 import {
@@ -218,10 +217,6 @@ export default class SnippetManagementEditSnippetController extends Controller {
       {
         label: this.intl.t('editor.variables.number'),
         component: NumberInsertComponent,
-      },
-      {
-        label: this.intl.t('editor.variables.address'),
-        component: VariablePluginAddressInsertVariableComponent,
       },
       {
         label: this.intl.t('editor.variables.date'),

--- a/app/controllers/template-management/edit.js
+++ b/app/controllers/template-management/edit.js
@@ -60,8 +60,6 @@ import { citationPlugin } from '@lblod/ember-rdfa-editor-lblod-plugins/plugins/c
 import { highlight } from '@lblod/ember-rdfa-editor/plugins/highlight/marks/highlight';
 import { color } from '@lblod/ember-rdfa-editor/plugins/color/marks/color';
 import {
-  address,
-  addressView,
   codelist,
   codelistView,
   date,
@@ -88,7 +86,6 @@ import PersonVariableInsertComponent from '@lblod/ember-rdfa-editor-lblod-plugin
 import NumberInsertComponent from '@lblod/ember-rdfa-editor-lblod-plugins/components/variable-plugin/number/insert';
 import DateInsertVariableComponent from '@lblod/ember-rdfa-editor-lblod-plugins/components/variable-plugin/date/insert-variable';
 import CodelistInsertComponent from '@lblod/ember-rdfa-editor-lblod-plugins/components/variable-plugin/codelist/insert';
-import VariablePluginAddressInsertVariableComponent from '@lblod/ember-rdfa-editor-lblod-plugins/components/variable-plugin/address/insert-variable';
 import SnippetInsertRdfaComponent from '@lblod/ember-rdfa-editor-lblod-plugins/components/snippet-plugin/snippet-insert-rdfa';
 import AutofilledInsertComponent from '@lblod/ember-rdfa-editor-lblod-plugins/components/variable-plugin/autofilled/insert';
 import {
@@ -188,7 +185,6 @@ export default class TemplateManagementEditController extends Controller {
         tableGroup: 'block',
         cellContent: 'block+',
       }),
-      address,
       date: date(this.config.date),
       text_variable,
       oslo_location: osloLocation(this.config.location),
@@ -241,10 +237,6 @@ export default class TemplateManagementEditController extends Controller {
       {
         label: this.intl.t('editor.variables.number'),
         component: NumberInsertComponent,
-      },
-      {
-        label: this.intl.t('editor.variables.address'),
-        component: VariablePluginAddressInsertVariableComponent,
       },
       {
         label: this.intl.t('editor.variables.date'),
@@ -372,7 +364,6 @@ export default class TemplateManagementEditController extends Controller {
           controller,
         ),
         link: linkView(this.config.link)(controller),
-        address: addressView(controller),
         date: dateView(this.config.date)(controller),
         number: numberView(controller),
         text_variable: textVariableView(controller),

--- a/app/templates/snippet-management/edit/edit-snippet.hbs
+++ b/app/templates/snippet-management/edit/edit-snippet.hbs
@@ -123,10 +123,6 @@
               @config={{this.config.snippet}}
             />
             <TemplateCommentsPlugin::Insert @controller={{this.editor}} />
-            <VariablePlugin::Address::Insert
-              @controller={{this.editor}}
-              @templateMode={{true}}
-            />
             {{#if this.activeNode}}
               <this.SnippetInsert
                 @controller={{this.editor}}
@@ -180,7 +176,6 @@
             @variableTypes={{this.variableTypes}}
             @templateMode={{true}}
           />
-          <VariablePlugin::Address::Edit @controller={{this.editor}} />
           <ArticleStructurePlugin::StructureCard
             @controller={{this.editor}}
             @options={{this.config.structures}}

--- a/app/templates/template-management/edit.hbs
+++ b/app/templates/template-management/edit.hbs
@@ -155,11 +155,6 @@
             {{#if this.supportsComments}}
               <TemplateCommentsPlugin::Insert @controller={{this.editor}} />
             {{/if}}
-            <VariablePlugin::Address::Insert
-              @controller={{this.editor}}
-              @templateMode={{true}}
-            />
-
             <SnippetPlugin::SnippetInsertPlaceholder
               @controller={{this.editor}}
               @config={{this.config.snippet}}
@@ -229,7 +224,6 @@
             @variableTypes={{this.variableTypes}}
             @templateMode={{true}}
           />
-          <VariablePlugin::Address::Edit @controller={{this.editor}} />
           <ArticleStructurePlugin::StructureCard
             @controller={{this.editor}}
             @options={{this.config.structures}}

--- a/package-lock.json
+++ b/package-lock.json
@@ -40,7 +40,7 @@
         "@lblod/ember-environment-banner": "^0.5.0",
         "@lblod/ember-mock-login": "^0.10.0",
         "@lblod/ember-rdfa-editor": "10.9.1",
-        "@lblod/ember-rdfa-editor-lblod-plugins": "26.1.0-dev.23bbb85064dc86744df1e40778809fbb82cbbdb7",
+        "@lblod/ember-rdfa-editor-lblod-plugins": "26.1.0-dev.05d24394216b47fd361f189d4ee4290599468733",
         "@release-it-plugins/lerna-changelog": "^6.0.0",
         "@tsconfig/ember": "^3.0.8",
         "broccoli-asset-rev": "^3.0.0",
@@ -12121,9 +12121,9 @@
       }
     },
     "node_modules/@lblod/ember-rdfa-editor-lblod-plugins": {
-      "version": "26.1.0-dev.23bbb85064dc86744df1e40778809fbb82cbbdb7",
-      "resolved": "https://registry.npmjs.org/@lblod/ember-rdfa-editor-lblod-plugins/-/ember-rdfa-editor-lblod-plugins-26.1.0-dev.23bbb85064dc86744df1e40778809fbb82cbbdb7.tgz",
-      "integrity": "sha512-l/isOAUhWIdRP5l8PdEfJ+JAwldRWh1EaZydHiLwyJX57BmJEk+8YIs/HMTpHDt/t8/4LUi1SoFSeEGFR7f/fQ==",
+      "version": "26.1.0-dev.05d24394216b47fd361f189d4ee4290599468733",
+      "resolved": "https://registry.npmjs.org/@lblod/ember-rdfa-editor-lblod-plugins/-/ember-rdfa-editor-lblod-plugins-26.1.0-dev.05d24394216b47fd361f189d4ee4290599468733.tgz",
+      "integrity": "sha512-Wgx5p6qgvi25/NOsZ80tAzkCBYFwpDnR5/Es3dPOQk4iUmHUdplie3HCWcM9/rUAAJXXxDcBfuSgV4io6Z2frA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "@lblod/ember-environment-banner": "^0.5.0",
     "@lblod/ember-mock-login": "^0.10.0",
     "@lblod/ember-rdfa-editor": "10.9.1",
-    "@lblod/ember-rdfa-editor-lblod-plugins": "26.1.0-dev.23bbb85064dc86744df1e40778809fbb82cbbdb7",
+    "@lblod/ember-rdfa-editor-lblod-plugins": "26.1.0-dev.05d24394216b47fd361f189d4ee4290599468733",
     "@release-it-plugins/lerna-changelog": "^6.0.0",
     "@tsconfig/ember": "^3.0.8",
     "broccoli-asset-rev": "^3.0.0",


### PR DESCRIPTION
## Overview
Updates to a plugins build with fixed RDFa output for locations and removes the address variable as that has not been updated to include these fixes.

##### connected issues and PRs:
Plugins PR: https://github.com/lblod/ember-rdfa-editor-lblod-plugins/pull/519
GN PR: https://github.com/lblod/frontend-gelinkt-notuleren/pull/794
Based on previous location branch: https://github.com/lblod/frontend-reglementaire-bijlage/pull/306

### Setup
N/A

### How to test/reproduce
Existing documents with address variables should now use the oslo location node. The locations inserted should include correct RDFa, see [plugins PR](https://github.com/lblod/ember-rdfa-editor-lblod-plugins/pull/519) for details.

### Challenges/uncertainties
N/A

### Checks PR readiness
- [ ] UI: works on smaller screen sizes
- [ ] UI: feedback for any loading/error states
- [ ] Check cancel/go-back flows
- [ ] Check database state correct when deleting/updating (especially regarding relationships)
- [x] changelog
- [x] npm lint
- [x] no new deprecations