### PR TITLE
Correctly link `document-container` resources to their `editor-document` versions

### DIFF
--- a/.changeset/fluffy-queens-double.md
+++ b/.changeset/fluffy-queens-double.md
@@ -1,0 +1,5 @@
+---
+"frontend-reglementaire-bijlage": patch
+---
+
+Store link between document-container and editor-document when saving a new version

--- a/app/components/snippet-list-form.js
+++ b/app/components/snippet-list-form.js
@@ -136,28 +136,31 @@ export default class SnippetListForm extends Component {
     const snippets = await this.snippetsRequest.promise;
     const snippetCount = snippets.length;
     const now = new Date();
+
     const snippetVersion = this.store.createRecord('snippet-version', {
       title: `Snippet created on ${new Date().toDateString()}`,
       createdOn: now,
       content: '',
     });
+    await snippetVersion.save();
+
     const snippet = this.store.createRecord('snippet', {
       position: snippetCount,
       createdOn: now,
       updatedOn: now,
-      currentVersion: snippetVersion,
       snippetList: this.snippetList,
+      currentVersion: snippetVersion,
     });
-    snippetVersion.snippet = snippet;
-    await snippetVersion.save();
     await snippet.save();
 
-    this.snippets = [...snippets, snippet];
+    snippetVersion.snippet = snippet;
+    await snippetVersion.save();
 
-    this.router.transitionTo('snippet-management.edit.edit-snippet', {
-      snippet,
-      snippetList: this.snippetList,
-    });
+    this.snippets = [...snippets, snippet];
+    this.router.transitionTo(
+      'snippet-management.edit.edit-snippet',
+      snippet.id,
+    );
   });
 
   updateImportedResourcesOnList = task(async () => {

--- a/app/controllers/template-management/edit.js
+++ b/app/controllers/template-management/edit.js
@@ -480,13 +480,15 @@ export default class TemplateManagementEditController extends Controller {
   save = task(async () => {
     const html = this.editor.htmlContent;
     const templateVersion = generateTemplate(this.editor);
-    const editorDocument = this.store.createRecord('editor-document');
-    editorDocument.content = html;
-    editorDocument.templateVersion = templateVersion;
-    editorDocument.createdOn = this.model.editorDocument.createdOn;
-    editorDocument.updatedOn = new Date();
-    editorDocument.title = this.model.editorDocument.title;
-    editorDocument.previousVersion = this.model.editorDocument;
+    const editorDocument = this.store.createRecord('editor-document', {
+      title: this.model.editorDocument.title,
+      content: html,
+      templateVersion: templateVersion,
+      createdOn: this.model.editorDocument.createdOn,
+      updatedOn: new Date(),
+      documentContainer: this.model.documentContainer,
+      previousVersion: this.model.editorDocument,
+    });
     await editorDocument.save();
 
     const documentContainer = this.model.documentContainer;

--- a/app/controllers/template-management/index.js
+++ b/app/controllers/template-management/index.js
@@ -102,15 +102,14 @@ export default class TemplateManagementIndexController extends Controller {
   @action
   startCreateTemplateFlow() {
     const documentContainer = this.store.createRecord('document-container');
-    const editorDocument = this.store.createRecord('editor-document');
-    editorDocument.content = '';
-    editorDocument.createdOn = new Date();
-    editorDocument.updatedOn = new Date();
-    editorDocument.title = '';
+    const editorDocument = this.store.createRecord('editor-document', {
+      title: '',
+      content: '',
+      createdOn: new Date(),
+      updatedOn: new Date(),
+    });
     this.editorDocument = editorDocument;
     this.documentContainer = documentContainer;
-
-    documentContainer.currentVersion = editorDocument;
 
     this.createTemplateModalIsOpen = true;
   }
@@ -130,12 +129,17 @@ export default class TemplateManagementIndexController extends Controller {
   saveTemplate = task(async (event) => {
     event.preventDefault();
     await this.editorDocument.save();
-    const folder = await this.store.findRecord(
+
+    this.documentContainer.folder = await this.store.findRecord(
       'editor-document-folder',
       this.templateTypeToCreate.folder,
     );
-    this.documentContainer.folder = folder;
+    this.documentContainer.currentVersion = this.editorDocument;
     await this.documentContainer.save();
+
+    this.editorDocument.documentContainer = this.documentContainer;
+    await this.editorDocument.save();
+
     this.createTemplateModalIsOpen = false;
     this.router.transitionTo(
       'template-management.edit',


### PR DESCRIPTION
## Overview
When saving a template (`editor-document`), correctly link it to its respective `document-container`.

**Update: this also fixes the following issues**
- When creating a new snippet, correctly link the snippet to snippet-version
- Fix an issue with the `undefined` in the url created when creating a snippet

##### connected issues and PRs:
https://github.com/lblod/app-reglementaire-bijlage/pull/90

### How to test/reproduce
Check-out https://github.com/lblod/app-reglementaire-bijlage/pull/90 for more information

### Checks PR readiness
- [x] UI: works on smaller screen sizes
- [x] UI: feedback for any loading/error states
- [x] Check cancel/go-back flows
- [x] Check database state correct when deleting/updating (especially regarding relationships)
- [x] changelog
- [x] npm lint
- [x] no new deprecations