### PR TITLE
internal: remove previous-version and next-version rel references

### DIFF
--- a/.changeset/metal-dodos-search.md
+++ b/.changeset/metal-dodos-search.md
@@ -1,0 +1,5 @@
+---
+"frontend-reglementaire-bijlage": patch
+---
+
+Remove references of unneeded `previousVersion` and `nextVersion` relationships

--- a/app/controllers/snippet-management/edit/edit-snippet.js
+++ b/app/controllers/snippet-management/edit/edit-snippet.js
@@ -389,7 +389,6 @@ export default class SnippetManagementEditSnippetController extends Controller {
       content: html,
       createdOn: now,
       title: currentVersion.title,
-      previousVersion: currentVersion,
       snippet,
     });
     currentVersion.validThrough = new Date();

--- a/app/controllers/template-management/edit.js
+++ b/app/controllers/template-management/edit.js
@@ -487,7 +487,6 @@ export default class TemplateManagementEditController extends Controller {
       createdOn: this.model.editorDocument.createdOn,
       updatedOn: new Date(),
       documentContainer: this.model.documentContainer,
-      previousVersion: this.model.editorDocument,
     });
     await editorDocument.save();
 

--- a/app/models/editor-document.js
+++ b/app/models/editor-document.js
@@ -11,10 +11,6 @@ export default class EditorDocumentModel extends Model {
   @attr('datetime') createdOn;
   @attr('datetime') updatedOn;
 
-  @belongsTo('editor-document', { inverse: 'nextVersion', async: true })
-  previousVersion;
-  @belongsTo('editor-document', { inverse: 'previousVersion', async: true })
-  nextVersion;
   @belongsTo('document-container', { inverse: 'revisions', async: true })
   documentContainer;
 

--- a/app/models/snippet-version.js
+++ b/app/models/snippet-version.js
@@ -8,5 +8,4 @@ export default class SnippetVersionModel extends Model {
   @attr('datetime') validThrough;
 
   @belongsTo('snippet', { inverse: 'revisions', async: true }) snippet;
-  @belongsTo('snippet-version', { inverse: null, async: true }) previousVersion;
 }


### PR DESCRIPTION
## Overview
This PR removes all references of the `nextVersion` and `previousVersion` relationships.
These relationships are not really used, and they further complicate code around working with documents and snippets.

##### connected issues and PRs:
None

### Setup
None

### How to test/reproduce
- Start the frontend
- Ensure it works as before: publishing, opening, saving documents/snippets should still work as expected

### Checks PR readiness
- [ ] UI: works on smaller screen sizes
- [ ] UI: feedback for any loading/error states
- [ ] Check cancel/go-back flows
- [ ] Check database state correct when deleting/updating (especially regarding relationships)
- [ ] changelog
- [ ] npm lint
- [ ] no new deprecations