### PR TITLE
GN-5171: drop legacy rdfa annotation feature

### DIFF
--- a/app/components/rdfa-editor-container.hbs
+++ b/app/components/rdfa-editor-container.hbs
@@ -32,14 +32,10 @@
     {{#if this.ready}}
       <EditorContainer
         @editorOptions={{hash
-          showRdfa='false'
           editRdfa='true'
-          showRdfaHighlight='true'
-          showRdfaHover='true'
           showPaper='true'
           showToolbarBottom=null
         }}
-        @showRdfaBlocks={{this.editor.showRdfaBlocks}}
       >
         <:top>
           {{yield to='top'}}

--- a/app/components/rdfa-editor-container.hbs
+++ b/app/components/rdfa-editor-container.hbs
@@ -3,7 +3,7 @@
     <div class="au-c-rdfa-editor">
       <div class="say-container say-container--sidebar-left say-container--paper say-container--sidebar-right">
         <div class="say-container__main">
-          <div class="say-editor rdfa-annotations rdfa-annotations-highlight rdfa-annotations-hover">
+          <div class="say-editor">
             <div class="say-editor__paper">
               <div class="au-c-scanner">
                 <div class="au-c-scanner__text">

--- a/app/styles/_shame.scss
+++ b/app/styles/_shame.scss
@@ -115,16 +115,6 @@
   display: none;
 }
 
-[property="eli:title"]:before {
-  content: "Document-titel" !important;
-}
-
-[lang="en-US"] {
-  [property="eli:title"]:before {
-    content: "Document title" !important;
-  }
-}
-
 .say-editable {
   outline: 0.1rem solid var(--au-gray-300);
   padding-top: 2px;

--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -5,7 +5,6 @@
 @import 'variable-plugin';
 @import 'besluit-plugin';
 @import 'generic-rdfa-variable';
-@import 'document-title-plugin';
 @import 'snippet-plugin';
 @import 'template-comments-plugin';
 @import 'confidentiality-plugin';

--- a/app/templates/snippet-management/edit/edit-snippet.hbs
+++ b/app/templates/snippet-management/edit/edit-snippet.hbs
@@ -22,7 +22,6 @@
   <RdfaEditorContainer
     @rdfaEditorInit={{this.handleRdfaEditorInit}}
     @editorDocument={{this.editorDocument}}
-    @showToggleRdfaAnnotations={{true}}
     @busy={{or this.save.isRunning}}
     @busyText={{t "template-edit.saving"}}
     @schema={{this.schema}}
@@ -81,9 +80,6 @@
           <:side as |Tb|>
             <Tb.Group>
               <TableOfContentsPlugin::ToolbarButton
-                @controller={{this.editor}}
-              />
-              <Plugins::RdfaBlockRender::RdfaBlocksToggle
                 @controller={{this.editor}}
               />
             </Tb.Group>

--- a/app/templates/template-management/edit.hbs
+++ b/app/templates/template-management/edit.hbs
@@ -49,7 +49,6 @@
   <RdfaEditorContainer
     @rdfaEditorInit={{this.handleRdfaEditorInit}}
     @editorDocument={{this.editorDocument}}
-    @showToggleRdfaAnnotations={{true}}
     @busy={{or this.save.isRunning}}
     @busyText={{t "template-edit.saving"}}
     @schema={{this.schema}}
@@ -110,9 +109,6 @@
           <:side as |Tb|>
             <Tb.Group>
               <TableOfContentsPlugin::ToolbarButton
-                @controller={{this.editor}}
-              />
-              <Plugins::RdfaBlockRender::RdfaBlocksToggle
                 @controller={{this.editor}}
               />
             </Tb.Group>

--- a/app/templates/template-management/publish.hbs
+++ b/app/templates/template-management/publish.hbs
@@ -28,7 +28,7 @@
           </c.header>
           <c.content>
             <div
-              class='say-editor say-content rdfa-annotations rdfa-annotations-highlight rdfa-annotations-hover'
+              class='say-editor say-content'
             >
               {{! template-lint-disable no-triple-curlies }}
               {{{this.model.currentVersion.templateVersion}}}
@@ -52,7 +52,7 @@
               <AuLoader>{{t 'utility.loading' }}</AuLoader>
             {{else}}
               <div
-                class='say-editor say-content rdfa-annotations rdfa-annotations-highlight rdfa-annotations-hover'
+                class='say-editor say-content'
               >
                 {{! template-lint-disable no-triple-curlies }}
                 {{{this.currentVersion}}}


### PR DESCRIPTION
### Overview
This PR includes adjustments to support the removal of the legacy RDFa annotation feature.
It builds upon https://github.com/lblod/ember-rdfa-editor/pull/1241 and https://github.com/lblod/ember-rdfa-editor-lblod-plugins/pull/529

Specifically, this PR includes the following:
- Removed the rdfa-annotations toggle
- Removed imports of certain legacy stylesheets
- Removed usage of legacy `rdfa-annotation` classes

##### connected issues and PRs:
[GN-5171](https://binnenland.atlassian.net/browse/GN-5171?atlOrigin=eyJpIjoiNjI1NWY4M2Q5YTM3NDIwZWFlNTQxYjUzN2M0ZTgxNmEiLCJwIjoiaiJ9)
https://github.com/lblod/ember-rdfa-editor/pull/1241
https://github.com/lblod/ember-rdfa-editor-lblod-plugins/pull/529

### How to test/reproduce
- Start the app
- Open the different type of editors used throughout the application + ensure their styling is still correct
  - Template editor (RS & Decision)
  - Snippet editor 
- Ensure the styling of previews (while saving and publishing) make sense

### Challenges/uncertainties
Removal of the `rdfa-annotations` stylesheet induced the removal of the left spacing in some editors. We might want to add this spacing back.

### Checks PR readiness
- [x] UI: feedback for any loading/error states
- [x] Check database state correct when deleting/updating (especially regarding relationships)
- [x] Check cancel/go-back flows
- [x] npm lint
- [ ] UI: works on smaller screen sizes
- [ ] changelog
