### PR TITLE
Cleanup deprecations introduce in Ember 5.x

### DIFF
--- a/.changeset/neat-spiders-hide.md
+++ b/.changeset/neat-spiders-hide.md
@@ -1,0 +1,5 @@
+---
+"frontend-reglementaire-bijlage": patch
+---
+
+Remove deprecation introduced in ember.js 5.x

--- a/app/components/file-upload-button.gjs
+++ b/app/components/file-upload-button.gjs
@@ -20,6 +20,7 @@ export default class FileUploadButton extends Component {
     <AuButton
       @icon={{@icon}}
       @loading={{@loading}}
+      @loadingMessage={{@loadingMessage}}
       {{on 'click' this.onClick}}
       ...attributes
     >{{yield}}</AuButton>

--- a/app/components/snippet-list-form.hbs
+++ b/app/components/snippet-list-form.hbs
@@ -120,6 +120,7 @@
     @disabled={{or this.invalidLabel @snippetList.isNew}}
     {{on "click" (perform this.createSnippet)}}
     @loading={{this.createSnippet.isRunning}}
+    @loadingMessage={{t 'utility.loading'}}
   >
     {{t "snippets.edit-snippet-list.snippet-creation.action"}}
   </AuButton>
@@ -208,7 +209,7 @@
     <AuButton
       @alert={{true}}
       @loading={{this.removeSnippet.isRunning}}
-      @loadingText={{t "utility.deleting"}}
+      @loadingMessage={{t 'utility.deleting'}}
       {{on "click" (perform this.removeSnippet)}}
     >
       {{t "snippets.edit-snippet-list.snippet-deletion.action.long"}}

--- a/app/components/template-exporter.gjs
+++ b/app/components/template-exporter.gjs
@@ -108,6 +108,7 @@ export default class TemplateExporter extends Component {
       {{on 'click' this.download.perform}}
       @disabled={{this.disabled}}
       @loading={{this.download.isRunning}}
+      @loadingMessage={{t 'utility.loading'}}
     >
       {{t 'template-export.button'}}
     </AuButton>

--- a/app/components/template-importer.gjs
+++ b/app/components/template-importer.gjs
@@ -95,6 +95,7 @@ export default class TemplateImporter extends Component {
       @accept='.zip'
       @onChange={{this.selectFile}}
       @loading={{this.upload.isRunning}}
+      @loadingMessage={{t 'utility.loading'}}
     >
       {{t 'template-import.button'}}
     </FileUploadButton>

--- a/app/services/current-session.js
+++ b/app/services/current-session.js
@@ -19,7 +19,7 @@ export default class CurrentSessionService extends Service {
       this.account = await this.store.findRecord('account', accountId, {
         include: 'user',
       });
-      this.user = await this.account.get('user');
+      this.user = await this.account.user;
 
       let groupId = this.session.data.authenticated.relationships.group.data.id;
       this.group = await this.store.findRecord('administrative-unit', groupId, {

--- a/app/templates/codelist-management/index.hbs
+++ b/app/templates/codelist-management/index.hbs
@@ -96,7 +96,7 @@
   <AuButton
     @alert={{true}}
     @loading={{this.removeCodelist.isRunning}}
-    @loadingText={{t 'utility.deleting'}}
+    @loadingMessage={{t 'utility.deleting'}}
     {{on 'click' (perform this.removeCodelist)}}
   >
     {{t 'codelist.crud.delete'}}

--- a/app/templates/snippet-management/index.hbs
+++ b/app/templates/snippet-management/index.hbs
@@ -115,7 +115,7 @@
     <AuButton
       @alert={{true}}
       @loading={{this.removeSnippetList.isRunning}}
-      @loadingText={{t "utility.deleting"}}
+      @loadingMessage={{t "utility.deleting"}}
       {{on "click" (perform this.removeSnippetList)}}
     >
       {{t "snippets.manage-snippet-lists.snippet-list-deletion.action.long"}}

--- a/app/templates/template-management/publish.hbs
+++ b/app/templates/template-management/publish.hbs
@@ -65,6 +65,7 @@
     <AuButton
       class='au-u-margin-top'
       @loading={{this.createPublishedResource.isRunning}}
+      @loadingMessage={{t 'utility.loading'}}
       @disabled={{this.createPublishedResource.isRunning}}
       {{on 'click' (perform this.createPublishedResource)}}
     >

--- a/tests/unit/models/code-list-test.js
+++ b/tests/unit/models/code-list-test.js
@@ -21,6 +21,6 @@ module('Unit | Model | code-list', function (hooks) {
     );
 
     const options = await codeList.concepts;
-    options.pushObject(option);
+    options.push(option);
   });
 });


### PR DESCRIPTION
## Overview
This PR includes a removal of (most) deprecations introduced in ember 5.x.

### Setup
It's possibly best to test with the `EXTEND_PROTOTYPES` flag set to false, just be aware that ember-drag-drop won't work, so that will need to be tested with it not set.

### How to test/reproduce
- Ensure every page/function works as before
- Pay special attention to the codelist edit page, as I had to make some internal changes to the `ChangesetList` implementation

### Checks PR readiness
- [x] UI: works on smaller screen sizes
- [x] UI: feedback for any loading/error states
- [x] Check cancel/go-back flows
- [x] Check database state correct when deleting/updating (especially regarding relationships)
- [x] changelog
- [x] npm lint
- [x] no new deprecations