### PR TITLE
Update editor packages

### DIFF
--- a/.changeset/fair-numbers-film.md
+++ b/.changeset/fair-numbers-film.md
@@ -1,0 +1,5 @@
+---
+"frontend-reglementaire-bijlage": patch
+---
+
+Update `@lblod/ember-rdfa-editor` to version [11.2.0](https://github.com/lblod/ember-rdfa-editor/releases/tag/v11.2.0)

--- a/.changeset/few-rings-dream.md
+++ b/.changeset/few-rings-dream.md
@@ -1,0 +1,5 @@
+---
+"frontend-reglementaire-bijlage": patch
+---
+
+Update `@lblod/ember-rdfa-editor-lblod-plugins` to version [28.0.0](https://github.com/lblod/ember-rdfa-editor-lblod-plugins/releases/tag/v28.0.0)

--- a/app/controllers/template-management/edit.js
+++ b/app/controllers/template-management/edit.js
@@ -286,17 +286,11 @@ export default class TemplateManagementEditController extends Controller {
   get config() {
     const env = getOwner(this).resolveRegistration('config:environment');
     return {
-      tableOfContents: [
-        {
-          nodeHierarchy: [
-            'title|chapter|section|subsection|article',
-            'structure_header|article_header',
-          ],
-          scrollContainer: () =>
-            document.getElementsByClassName('say-container__main')[0],
-          scrollingPadding: 300,
-        },
-      ],
+      tableOfContents: {
+        scrollContainer: () =>
+          document.getElementsByClassName('say-container__main')[0],
+        scrollingPadding: 300,
+      },
       date: {
         formats: [
           {

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "@lblod/ember-environment-banner": "^0.6.0",
     "@lblod/ember-mock-login": "^0.10.0",
     "@lblod/ember-rdfa-editor": "11.2.0",
-    "@lblod/ember-rdfa-editor-lblod-plugins": "27.0.3",
+    "@lblod/ember-rdfa-editor-lblod-plugins": "28.0.0",
     "@release-it-plugins/lerna-changelog": "^6.0.0",
     "@tsconfig/ember": "^3.0.8",
     "@types/lodash.mergewith": "^4.6.9",

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "@lblod/ember-acmidm-login": "^2.1.0",
     "@lblod/ember-environment-banner": "^0.6.0",
     "@lblod/ember-mock-login": "^0.10.0",
-    "@lblod/ember-rdfa-editor": "11.1.0",
+    "@lblod/ember-rdfa-editor": "11.2.0",
     "@lblod/ember-rdfa-editor-lblod-plugins": "27.0.3",
     "@release-it-plugins/lerna-changelog": "^6.0.0",
     "@tsconfig/ember": "^3.0.8",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -147,11 +147,11 @@ importers:
         specifier: ^0.10.0
         version: 0.10.2(@glint/template@1.5.1)(ember-simple-auth@6.1.0(@babel/core@7.26.7)(@ember/test-helpers@3.3.1(@babel/core@7.26.7)(@glint/template@1.5.1)(ember-source@5.12.0(patch_hash=rkcvrh53qmynhoxmyesuzuwpyq)(@glimmer/component@1.1.2(@babel/core@7.26.7))(@glint/template@1.5.1)(rsvp@4.8.5)(webpack@5.97.1))(webpack@5.97.1))(@glint/template@1.5.1)(ember-source@5.12.0(patch_hash=rkcvrh53qmynhoxmyesuzuwpyq)(@glimmer/component@1.1.2(@babel/core@7.26.7))(@glint/template@1.5.1)(rsvp@4.8.5)(webpack@5.97.1))(eslint@8.57.1))(ember-source@5.12.0(patch_hash=rkcvrh53qmynhoxmyesuzuwpyq)(@glimmer/component@1.1.2(@babel/core@7.26.7))(@glint/template@1.5.1)(rsvp@4.8.5)(webpack@5.97.1))(webpack@5.97.1)
       '@lblod/ember-rdfa-editor':
-        specifier: 11.1.0
-        version: 11.1.0(ks7gaj74oeyl75bibrwcljbkdy)
+        specifier: 11.2.0
+        version: 11.2.0(ks7gaj74oeyl75bibrwcljbkdy)
       '@lblod/ember-rdfa-editor-lblod-plugins':
         specifier: 27.0.3
-        version: 27.0.3(cjmohsizspe4m4eytf7vzypyoi)
+        version: 27.0.3(vsvggq7bisajpcay3jqpajhioi)
       '@release-it-plugins/lerna-changelog':
         specifier: ^6.0.0
         version: 6.1.0(release-it@16.3.0(encoding@0.1.13)(typescript@5.7.3))
@@ -1565,8 +1565,8 @@ packages:
       ember-template-imports:
         optional: true
 
-  '@lblod/ember-rdfa-editor@11.1.0':
-    resolution: {integrity: sha512-tmGE4wwSkVG8z/qPvOldfGmBv0qdrr5TErjcSJVYz7WyNe3DJ9TZ5xUAUJFXQPDYValsigniq6j1v1S10Yatzg==}
+  '@lblod/ember-rdfa-editor@11.2.0':
+    resolution: {integrity: sha512-ihXPcHabbZplzu4VfptE4Og0d524OBUXpkbacii30gvxw3z/2979lL6zovFE2L0mfKfWmuzw5Tpt+5PYz8npSw==}
     peerDependencies:
       '@appuniversum/ember-appuniversum': ^3.5.0
       '@ember/test-helpers': ^2.9.4 || ^3.2.1 || ^4.0.2 || ^5.0.0
@@ -10561,7 +10561,7 @@ snapshots:
       - supports-color
       - webpack
 
-  '@lblod/ember-rdfa-editor-lblod-plugins@27.0.3(cjmohsizspe4m4eytf7vzypyoi)':
+  '@lblod/ember-rdfa-editor-lblod-plugins@27.0.3(vsvggq7bisajpcay3jqpajhioi)':
     dependencies:
       '@appuniversum/ember-appuniversum': 3.7.0(swad3rgq7zjbnd7skqhsvp43fm)
       '@babel/core': 7.26.7
@@ -10571,7 +10571,7 @@ snapshots:
       '@curvenote/prosemirror-utils': 1.0.5(prosemirror-model@1.24.1)(prosemirror-state@1.4.3)
       '@ember/string': 3.1.1
       '@embroider/macros': 1.16.10(@glint/template@1.5.1)
-      '@lblod/ember-rdfa-editor': 11.1.0(ks7gaj74oeyl75bibrwcljbkdy)
+      '@lblod/ember-rdfa-editor': 11.2.0(ks7gaj74oeyl75bibrwcljbkdy)
       '@lblod/marawa': 0.8.0-beta.6
       '@lblod/template-uuid-instantiator': 1.0.3
       '@rdfjs/data-model': 2.1.0
@@ -10626,7 +10626,7 @@ snapshots:
       - web-streams-polyfill
       - webpack
 
-  '@lblod/ember-rdfa-editor@11.1.0(ks7gaj74oeyl75bibrwcljbkdy)':
+  '@lblod/ember-rdfa-editor@11.2.0(ks7gaj74oeyl75bibrwcljbkdy)':
     dependencies:
       '@appuniversum/ember-appuniversum': 3.7.0(swad3rgq7zjbnd7skqhsvp43fm)
       '@codemirror/commands': 6.8.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -150,8 +150,8 @@ importers:
         specifier: 11.2.0
         version: 11.2.0(ks7gaj74oeyl75bibrwcljbkdy)
       '@lblod/ember-rdfa-editor-lblod-plugins':
-        specifier: 27.0.3
-        version: 27.0.3(vsvggq7bisajpcay3jqpajhioi)
+        specifier: 28.0.0
+        version: 28.0.0(vsvggq7bisajpcay3jqpajhioi)
       '@release-it-plugins/lerna-changelog':
         specifier: ^6.0.0
         version: 6.1.0(release-it@16.3.0(encoding@0.1.13)(typescript@5.7.3))
@@ -1541,15 +1541,15 @@ packages:
       ember-simple-auth: ^6.0.0
       ember-source: '>= 4.0.0'
 
-  '@lblod/ember-rdfa-editor-lblod-plugins@27.0.3':
-    resolution: {integrity: sha512-z/39zLgXJuSpA5TiRAi4lLWsZzxyoe+iyA25YpqjCS77/R9TDr26ftUOGCwMuL/omqbuUSOyHslksE98NK4F4A==}
+  '@lblod/ember-rdfa-editor-lblod-plugins@28.0.0':
+    resolution: {integrity: sha512-gSBpTZJvi6/ektmnuiSPeWSOaIE99nEHKh21nQtkhtcupOsn+1cDxI0TQqrhSsTdEHivcEON9dihoUB8UtWVDg==}
     engines: {node: '>= 18'}
     peerDependencies:
-      '@appuniversum/ember-appuniversum': ^3.4.1
+      '@appuniversum/ember-appuniversum': ^3.5.0
       '@ember/string': 3.x
       '@glint/template': ^1.4.0
       '@lblod/ember-rdfa-editor': ^11.0.0
-      ember-concurrency: ^3.1.0 || ^4.0.2
+      ember-concurrency: ^4.0.2
       ember-element-helper: ^0.8.6
       ember-intl: ^7.0.0
       ember-leaflet: ^5.1.3
@@ -10561,7 +10561,7 @@ snapshots:
       - supports-color
       - webpack
 
-  '@lblod/ember-rdfa-editor-lblod-plugins@27.0.3(vsvggq7bisajpcay3jqpajhioi)':
+  '@lblod/ember-rdfa-editor-lblod-plugins@28.0.0(vsvggq7bisajpcay3jqpajhioi)':
     dependencies:
       '@appuniversum/ember-appuniversum': 3.7.0(swad3rgq7zjbnd7skqhsvp43fm)
       '@babel/core': 7.26.7


### PR DESCRIPTION
## Overview
This PR updates the following packages:
- `@lblod/ember-rdfa-editor` to version [11.2.0](https://github.com/lblod/ember-rdfa-editor/releases/tag/v11.2.0)
- `@lblod/ember-rdfa-editor-lblod-plugins` to version [28.0.0](https://github.com/lblod/ember-rdfa-editor-lblod-plugins/releases/tag/v28.0.0)

This PR also includes an adjustment to support the new table-of-contents API.