### PR TITLE
Style variables as orange in previews

### DIFF
--- a/.changeset/khaki-teachers-tan.md
+++ b/.changeset/khaki-teachers-tan.md
@@ -1,0 +1,5 @@
+---
+"frontend-reglementaire-bijlage": minor
+---
+
+Update @lblod/ember-rdfa-editor-lblod-plugins to 29.1.0

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "@lblod/ember-environment-banner": "^0.6.0",
     "@lblod/ember-mock-login": "^0.10.0",
     "@lblod/ember-rdfa-editor": "11.3.0",
-    "@lblod/ember-rdfa-editor-lblod-plugins": "28.2.3",
+    "@lblod/ember-rdfa-editor-lblod-plugins": "29.1.0",
     "@release-it-plugins/lerna-changelog": "^6.0.0",
     "@tsconfig/ember": "^3.0.8",
     "@types/lodash.mergewith": "^4.6.9",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -150,8 +150,8 @@ importers:
         specifier: 11.3.0
         version: 11.3.0(ks7gaj74oeyl75bibrwcljbkdy)
       '@lblod/ember-rdfa-editor-lblod-plugins':
-        specifier: 28.2.3
-        version: 28.2.3(cojf56x2miqtrqpsegx6qy7pmu)
+        specifier: 29.1.0
+        version: 29.1.0(cojf56x2miqtrqpsegx6qy7pmu)
       '@release-it-plugins/lerna-changelog':
         specifier: ^6.0.0
         version: 6.1.0(release-it@16.3.0(encoding@0.1.13)(typescript@5.7.3))
@@ -1541,8 +1541,8 @@ packages:
       ember-simple-auth: ^6.0.0
       ember-source: '>= 4.0.0'
 
-  '@lblod/ember-rdfa-editor-lblod-plugins@28.2.3':
-    resolution: {integrity: sha512-e3oT6WfwMIiQ1Bz1BQogCYAEw5EmqTnzAPFeja4izRAG1Gr7nMuYbL5w3xeDBUCEE2gfXKqSOoAktfcD6+m/CA==}
+  '@lblod/ember-rdfa-editor-lblod-plugins@29.1.0':
+    resolution: {integrity: sha512-ill34wCKFosxsgb4Y6+ba1yax6Q/iSCYCUxDQ9ZfBWKBKBqNquFVFkywU4oqGXF3wQOohtyDsL7THrmjbUpjKg==}
     engines: {node: '>= 18'}
     peerDependencies:
       '@appuniversum/ember-appuniversum': ^3.5.0
@@ -1877,8 +1877,8 @@ packages:
   '@rdfjs/parser-jsonld@2.1.3':
     resolution: {integrity: sha512-VYnPEwVdqFAPTo9F8XIN4UpGPdNzhBaCFv5b5OT74pA7H8so4aTno3Yd6M5I9bhTrUoCQjpjgr+ugYlvWxdBIA==}
 
-  '@rdfjs/parser-n3@2.0.2':
-    resolution: {integrity: sha512-rrrvyh+kkj9ndwep2h6nYmugIfggDOC9uGpmDAHn/I/z52K7dHxi7xOkPPrezTsIbgNvFhV3zS7mzyObRxcLWA==}
+  '@rdfjs/parser-n3@2.1.0':
+    resolution: {integrity: sha512-/DiosB+0vPzgAs1WXcCB8MbA5hqq0fIh9VhMg7fBmoJ/I8Xl6Op/AOxVu9x1XZCHSNwO/VsJT/HYKEctZVRKSQ==}
 
   '@rdfjs/prefix-map@0.1.2':
     resolution: {integrity: sha512-qapFYVPYyYepg0sFy7T512667iZsN9a3RNcyNBTBV+O8wrU3v/URQZOipCTNrEm1BXzZ7KCK1Yi8HrE1y+uRuQ==}
@@ -1886,8 +1886,8 @@ packages:
   '@rdfjs/score@0.1.2':
     resolution: {integrity: sha512-HKiC6q6sCsEPYVf9B4k/R0Hd+9e0QsjKr4zRdfuv6V4VPiPyzHfAsSUiFfRdi8UvNfpdKmoSWX8PM/ZIPwvq1g==}
 
-  '@rdfjs/serializer-jsonld-ext@4.0.0':
-    resolution: {integrity: sha512-HP5DCmhyfVuQuk58AO5vzNY+dIFVHe2oHY8NX2K+3XmrTmu/yzrFzPbDeU9Cwr71XC4RifEMoksIg+8jnhxmfQ==}
+  '@rdfjs/serializer-jsonld-ext@4.0.1':
+    resolution: {integrity: sha512-eGNAdhsV8wkmCadyIN+PBfsN+BIiqplAd5VMc++wf5McsVi/vPNrWcBINdrNnlegml8nLUy0rlKztCQ/4pxW8w==}
 
   '@rdfjs/serializer-jsonld@2.0.1':
     resolution: {integrity: sha512-O8WzdY7THsse/nMsrMLd2e51ADHO2SIUrkiZ9Va/8W3lXeeeiwDRPMppWy/i9yL4q6EM8iMW1riV7E0mK3fsBQ==}
@@ -1895,8 +1895,8 @@ packages:
   '@rdfjs/serializer-ntriples@2.0.1':
     resolution: {integrity: sha512-G1ZI0qaN/MUHxeCwr59JscO2LdyIb6MNQdXOv7NFBZuodyHsxxhJRFmMVn+3SEXeNJbVeEEbWBrLglCUgJ8XjQ==}
 
-  '@rdfjs/serializer-turtle@1.1.4':
-    resolution: {integrity: sha512-fw58pfAuIZblNzf8Gwl6mxfNkPH+/4Q1GwF0GFaSHg9yT0sQ1S+EzaqEVXl0MLPquEKTAMJFBs1fkdwUNq8Qww==}
+  '@rdfjs/serializer-turtle@1.1.5':
+    resolution: {integrity: sha512-uvIFUOuMuk8JrJnng/tWKIQ+8XI6YLEms75YdvZ49LtIyyfbDqKz76EybgnD/zZYfMhVVkguKtheBC9h08g1PQ==}
 
   '@rdfjs/sink-map@2.0.1':
     resolution: {integrity: sha512-BwCTTsMN/tfQl6QzD2oHn9A08e4af+hlzAz/d5XXrlOkYMEDUAqFuh2Odj9EbayhAEeN4wA743Mj2yC0/s69rg==}
@@ -2112,8 +2112,8 @@ packages:
   '@types/node@14.0.23':
     resolution: {integrity: sha512-Z4U8yDAl5TFkmYsZdFPdjeMa57NOvnaf1tljHzhouaPEp7LCj2JKkejpI1ODviIAQuW4CcQmxkQ77rnLsOOoKw==}
 
-  '@types/node@18.19.74':
-    resolution: {integrity: sha512-HMwEkkifei3L605gFdV+/UwtpxP6JSzM+xFk2Ia6DNFSwSVBRh9qp5Tgf4lNFOMfPVuU0WnkcWpXZpgn5ufO4A==}
+  '@types/node@18.19.84':
+    resolution: {integrity: sha512-ACYy2HGcZPHxEeWTqowTF7dhXN+JU1o7Gr4b41klnn6pj2LD6rsiGqSZojMdk1Jh2ys3m76ap+ae1vvE4+5+vg==}
 
   '@types/node@22.10.10':
     resolution: {integrity: sha512-X47y/mPNzxviAGY5TcYPtYL8JsY3kAq2n8fMmKoRCxq/c4v4pyGNCzM2R6+M5/umG4ZfHuT+sgqDYqWc9rJ6ww==}
@@ -7300,8 +7300,8 @@ packages:
     resolution: {integrity: sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
 
-  readable-web-to-node-stream@3.0.2:
-    resolution: {integrity: sha512-ePeK6cc1EcKLEhJFt/AebMCLL+GgSKhuygrZ/GLaKZYEecIgIECf4UaUuaByiGtzckwR4ain9VzUh95T1exYGw==}
+  readable-web-to-node-stream@3.0.4:
+    resolution: {integrity: sha512-9nX56alTf5bwXQ3ZDipHJhusu9NTQJ/CVPtb/XHAJCXihZeitfJvIRS4GqQ/mfIoOE3IelHMrpayVrosdHBuLw==}
     engines: {node: '>=8'}
 
   readdirp@4.1.1:
@@ -8367,8 +8367,8 @@ packages:
   undici-types@6.20.0:
     resolution: {integrity: sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==}
 
-  undici@5.28.5:
-    resolution: {integrity: sha512-zICwjrDrcrUE0pyyJc1I2QzBkLM8FINsgOrt6WjA+BgajVq9Nxu2PbFFXUrAggLfDXlZGZBVZYw7WNV5KiBiBA==}
+  undici@5.29.0:
+    resolution: {integrity: sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg==}
     engines: {node: '>=14.0'}
 
   unicode-canonical-property-names-ecmascript@2.0.1:
@@ -9839,7 +9839,7 @@ snapshots:
     dependencies:
       ky: 0.33.3
       ky-universal: 0.11.0(ky@0.33.3)(web-streams-polyfill@3.3.3)
-      undici: 5.28.5
+      undici: 5.29.0
     transitivePeerDependencies:
       - web-streams-polyfill
 
@@ -10561,7 +10561,7 @@ snapshots:
       - supports-color
       - webpack
 
-  '@lblod/ember-rdfa-editor-lblod-plugins@28.2.3(cojf56x2miqtrqpsegx6qy7pmu)':
+  '@lblod/ember-rdfa-editor-lblod-plugins@29.1.0(cojf56x2miqtrqpsegx6qy7pmu)':
     dependencies:
       '@appuniversum/ember-appuniversum': 3.7.0(swad3rgq7zjbnd7skqhsvp43fm)
       '@babel/core': 7.26.7
@@ -10576,7 +10576,7 @@ snapshots:
       '@lblod/template-uuid-instantiator': 1.0.3
       '@rdfjs/data-model': 2.1.0
       '@rdfjs/dataset': 2.0.2
-      '@rdfjs/parser-n3': 2.0.2
+      '@rdfjs/parser-n3': 2.1.0
       '@types/rdf-validate-shacl': 0.4.9
       '@types/rdfjs__parser-n3': 2.0.6
       buffer: 6.0.3
@@ -11009,11 +11009,11 @@ snapshots:
   '@rdfjs/formats@4.0.1(web-streams-polyfill@3.3.3)':
     dependencies:
       '@rdfjs/parser-jsonld': 2.1.3
-      '@rdfjs/parser-n3': 2.0.2
+      '@rdfjs/parser-n3': 2.1.0
       '@rdfjs/serializer-jsonld': 2.0.1
-      '@rdfjs/serializer-jsonld-ext': 4.0.0(web-streams-polyfill@3.3.3)
+      '@rdfjs/serializer-jsonld-ext': 4.0.1(web-streams-polyfill@3.3.3)
       '@rdfjs/serializer-ntriples': 2.0.1
-      '@rdfjs/serializer-turtle': 1.1.4
+      '@rdfjs/serializer-turtle': 1.1.5
       '@rdfjs/sink-map': 2.0.1
       rdfxml-streaming-parser: 3.0.1
     transitivePeerDependencies:
@@ -11045,7 +11045,7 @@ snapshots:
       jsonld-streaming-parser: 5.0.0
       readable-stream: 4.7.0
 
-  '@rdfjs/parser-n3@2.0.2':
+  '@rdfjs/parser-n3@2.1.0':
     dependencies:
       '@rdfjs/data-model': 2.1.0
       '@rdfjs/sink': 2.0.1
@@ -11064,7 +11064,7 @@ snapshots:
       '@rdfjs/term-set': 2.0.3
       '@rdfjs/to-ntriples': 3.0.1
 
-  '@rdfjs/serializer-jsonld-ext@4.0.0(web-streams-polyfill@3.3.3)':
+  '@rdfjs/serializer-jsonld-ext@4.0.1(web-streams-polyfill@3.3.3)':
     dependencies:
       '@rdfjs/sink': 2.0.1
       jsonld: 8.3.3(web-streams-polyfill@3.3.3)
@@ -11085,7 +11085,7 @@ snapshots:
       duplex-to: 2.0.0
       readable-stream: 4.7.0
 
-  '@rdfjs/serializer-turtle@1.1.4':
+  '@rdfjs/serializer-turtle@1.1.5':
     dependencies:
       '@rdfjs/data-model': 2.1.0
       '@rdfjs/namespace': 2.0.1
@@ -11376,7 +11376,7 @@ snapshots:
 
   '@types/node@14.0.23': {}
 
-  '@types/node@18.19.74':
+  '@types/node@18.19.84':
     dependencies:
       undici-types: 5.26.5
 
@@ -15318,7 +15318,7 @@ snapshots:
       minimist: 1.2.8
       n3: 1.23.1
       rdf-string: 1.6.3
-      readable-web-to-node-stream: 3.0.2
+      readable-web-to-node-stream: 3.0.4
       sparqljs: 3.7.3
       sparqljson-parse: 2.2.0
       sparqlxml-parse: 2.1.1
@@ -16632,7 +16632,7 @@ snapshots:
   jsonld-context-parser@3.0.0:
     dependencies:
       '@types/http-link-header': 1.0.7
-      '@types/node': 18.19.74
+      '@types/node': 18.19.84
       http-link-header: 1.1.3
       relative-to-absolute-iri: 1.0.7
 
@@ -18260,9 +18260,9 @@ snapshots:
       process: 0.11.10
       string_decoder: 1.3.0
 
-  readable-web-to-node-stream@3.0.2:
+  readable-web-to-node-stream@3.0.4:
     dependencies:
-      readable-stream: 3.6.2
+      readable-stream: 4.7.0
 
   readdirp@4.1.1: {}
 
@@ -19581,7 +19581,7 @@ snapshots:
 
   undici-types@6.20.0: {}
 
-  undici@5.28.5:
+  undici@5.29.0:
     dependencies:
       '@fastify/busboy': 2.1.1
 


### PR DESCRIPTION
## Overview
Just an update to the latest plugins.

##### connected issues and PRs:
Jira ticket: [binnenland.atlassian.net/browse/GN-5525](https://binnenland.atlassian.net/browse/GN-5525)
Plugins PR: https://github.com/lblod/ember-rdfa-editor-lblod-plugins/pull/559
GN PR: https://github.com/lblod/frontend-gelinkt-notuleren/pull/841

### Setup
Can be useful to test alongside the GN PR as the published templates and snippets should have the correct styling when published using this version.

### How to test/reproduce
Publish previews show any variables (or OSLO locations) highlighted in orange. These should also show up correctly in GN (with the correct branch).

### Challenges/uncertainties
N/A

### Checks PR readiness
- [ ] UI: works on smaller screen sizes
- [ ] UI: feedback for any loading/error states
- [ ] Check cancel/go-back flows
- [ ] Check database state correct when deleting/updating (especially regarding relationships)
- [x] changelog
- [x] npm lint
- [x] no new deprecations