### PR TITLE
fix(styling): remove conflicting powerselect styles

### DIFF
--- a/.changeset/pretty-radios-refuse.md
+++ b/.changeset/pretty-radios-refuse.md
@@ -1,0 +1,5 @@
+---
+"frontend-reglementaire-bijlage": patch
+---
+
+Remove usage of default power-select styles, these conflict with the styles provided by appuniversum

--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -1,4 +1,3 @@
-@import "ember-power-select";
 @import "@appuniversum/ember-appuniversum/styles";
 @import '@lblod/ember-rdfa-editor';
 @import 'date-plugin';


### PR DESCRIPTION
## Overview
Remove usage of default power-select styles, these conflict with the styles provided by appuniversum

### How to test/reproduce
- Start the app and open a page contain a power-select component
- Ensure that the power-select is now displayed correctly and no longer contains any visual bugs